### PR TITLE
Add __hash__ method to keys and signature

### DIFF
--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -66,7 +66,7 @@ class BackendProxied(object):
             return cls._backend
 
 
-class BaseKey(ByteString):
+class BaseKey(ByteString, collections.Hashable):
     _raw_key = None
 
     def _as_hex(self):
@@ -74,6 +74,9 @@ class BaseKey(ByteString):
 
     def __bytes__(self):
         return self._raw_key
+
+    def __hash__(self):
+        return big_endian_to_int(keccak(bytes(self)))
 
     def __str__(self):
         if sys.version_info.major == 2:
@@ -222,6 +225,9 @@ class Signature(ByteString, BackendProxied):
 
     def _as_hex(self):
         return '0x' + codecs.decode(codecs.encode(bytes(self), 'hex'), 'ascii')
+
+    def __hash__(self):
+        return big_endian_to_int(keccak(bytes(self)))
 
     def __bytes__(self):
         vb = int_to_byte(self.v - 27)

--- a/tests/backends/test_native_backend_against_coincurve.py
+++ b/tests/backends/test_native_backend_against_coincurve.py
@@ -33,7 +33,7 @@ message_hash_st = st.binary(min_size=32, max_size=32)
 MSG = b'message'
 MSGHASH = keccak(MSG)
 
-MAX_EXAMPLES = 10000
+MAX_EXAMPLES = 200
 
 
 @pytest.fixture

--- a/tests/backends/test_native_backend_against_coincurve.py
+++ b/tests/backends/test_native_backend_against_coincurve.py
@@ -2,6 +2,7 @@ import pytest
 
 from hypothesis import (
     given,
+    settings,
     strategies as st,
 )
 
@@ -32,6 +33,8 @@ message_hash_st = st.binary(min_size=32, max_size=32)
 MSG = b'message'
 MSGHASH = keccak(MSG)
 
+MAX_EXAMPLES = 10000
+
 
 @pytest.fixture
 def native_backend():
@@ -44,6 +47,7 @@ def coincurve_backend():
 
 
 @given(private_key_bytes=private_key_st)
+@settings(max_examples=MAX_EXAMPLES)
 def test_public_key_generation_is_equal(private_key_bytes,
                                         native_backend,
                                         coincurve_backend):
@@ -54,6 +58,7 @@ def test_public_key_generation_is_equal(private_key_bytes,
 
 
 @given(private_key_bytes=private_key_st, message_hash=message_hash_st)
+@settings(max_examples=MAX_EXAMPLES)
 def test_native_to_coincurve_recover(private_key_bytes,
                                      message_hash,
                                      native_backend,
@@ -66,6 +71,7 @@ def test_native_to_coincurve_recover(private_key_bytes,
 
 
 @given(private_key_bytes=private_key_st, message_hash=message_hash_st)
+@settings(max_examples=MAX_EXAMPLES)
 def test_coincurve_to_native_recover(private_key_bytes,
                                      message_hash,
                                      native_backend,


### PR DESCRIPTION
The key and signature objects needed to be hashable.