### PR TITLE
More granular control over address formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pip install ethereum-keys
 '0x1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f70beaf8f588b541507fed6a642c5ab42dfdf8120a7f639de5122d47a69a8e8d1'
 >>> signature
 '0xccda990dba7864b79dc49158fea269338a1cf5747bc4c4bf1b96823e31a0997e7d1e65c06c5bf128b7109e1b4b9ba8d1305dc33f32f624695b2fa8e02c12c1e000'
->>> pk.public_key.to_address()
+>>> pk.public_key.to_checksum_address()
 '0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1'
 >>> signature.verify_msg(b'a message', pk.public_key)
 True
@@ -142,7 +142,17 @@ hash of the `message`.
 
 #### `PublicKey.to_address() -> text`
 
+Returns the hex encoded ethereum address for this public key.
+
+
+#### `PublicKey.to_checksum_address() -> text`
+
 Returns the ERC55 checksum formatted ethereum address for this public key.
+
+
+#### `PublicKey.to_canonical_address() -> bytes`
+
+Returns the 20-byte representation of the ethereum address for this public key.
 
 
 ### `KeyAPI.PrivateKey(private_key_bytes)`

--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -10,6 +10,7 @@ from eth_utils import (
     int_to_big_endian,
     keccak,
     to_checksum_address,
+    to_normalized_address,
 )
 
 from eth_keys.utils.address import (
@@ -129,8 +130,17 @@ class PublicKey(BaseKey, BackendProxied):
     def verify_msg_hash(self, message_hash, signature):
         return self.backend.ecdsa_verify(message_hash, signature, self)
 
-    def to_address(self):
+    #
+    # Ethereum address conversions
+    #
+    def to_checksum_address(self):
         return to_checksum_address(public_key_bytes_to_address(bytes(self)))
+
+    def to_address(self):
+        return to_normalized_address(public_key_bytes_to_address(bytes(self)))
+
+    def to_canonical_address(self):
+        return public_key_bytes_to_address(bytes(self))
 
 
 class PrivateKey(BaseKey, BackendProxied):

--- a/tests/core/test_key_and_signature_datastructures.py
+++ b/tests/core/test_key_and_signature_datastructures.py
@@ -6,6 +6,9 @@ from eth_utils import (
     decode_hex,
     keccak,
     is_same_address,
+    is_normalized_address,
+    is_checksum_address,
+    is_canonical_address,
 )
 
 from eth_keys.backends import NativeECCBackend
@@ -88,4 +91,17 @@ def test_recover_from_signature_obj(ecc_backend, private_key):
 
 def test_to_address_from_public_key(private_key):
     address = private_key.public_key.to_address()
+    assert is_normalized_address(address)
+    assert is_same_address(address, ADDRESS)
+
+
+def test_to_checksum_address_from_public_key(private_key):
+    address = private_key.public_key.to_checksum_address()
+    assert is_checksum_address(address)
+    assert is_same_address(address, ADDRESS)
+
+
+def test_to_canonical_address_from_public_key(private_key):
+    address = private_key.public_key.to_canonical_address()
+    assert is_canonical_address(address)
     assert is_same_address(address, ADDRESS)


### PR DESCRIPTION
Found I wanted more than just `to_address()`.  Was good to be able to pull it in the raw format