### PR TITLE
Add BadSignature error

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,3 +239,18 @@ This method returns a `PublicKey` instance recovered from the signature.
 
 Same as `Signature.recover_msg` except that `message_hash` should be the Keccak
 hash of the `message`.
+
+
+### Exceptions
+
+#### `eth_api.exceptions.ValidationError`
+
+This error is raised during instantaition of any of the `PublicKey`,
+`PrivateKey` or `Signature` classes if their constructor parameters are
+invalid.
+
+
+#### `eth_api.exceptions.BadSignature`
+
+This error is raised from any of the `recover` or `verify` methods involving
+signatures if the signature is invalid.

--- a/eth_keys/backends/native/ecdsa.py
+++ b/eth_keys/backends/native/ecdsa.py
@@ -18,6 +18,9 @@ from eth_keys.constants import (
     SECPK1_A as A,
     SECPK1_B as B,
 )
+from eth_keys.exceptions import (
+    BadSignature,
+)
 
 from eth_keys.utils.numeric import (
     int_to_byte,
@@ -106,7 +109,7 @@ def ecdsa_raw_verify(msg_hash, vrs, public_key_bytes):
 
     v, r, s = vrs
     if not (27 <= v <= 34):
-        raise ValueError("Invalid Signature")
+        raise BadSignature("Invalid Signature")
 
     w = inv(s, N)
     z = big_endian_to_int(msg_hash)
@@ -123,7 +126,7 @@ def ecdsa_raw_recover(msg_hash, vrs):
     v, r, s = vrs
 
     if not (27 <= v <= 34):
-        raise ValueError("%d must in range 27-31" % v)
+        raise BadSignature("%d must in range 27-31" % v)
 
     x = r
 
@@ -133,7 +136,7 @@ def ecdsa_raw_recover(msg_hash, vrs):
     # If xcubedaxb is not a quadratic residue, then r cannot be the x coord
     # for a point on the curve, and so the sig is invalid
     if (xcubedaxb - y * y) % P != 0 or not (r % N) or not (s % N):
-        raise ValueError("Invalid signature")
+        raise BadSignature("Invalid signature")
     z = big_endian_to_int(msg_hash)
     Gz = jacobian_multiply((Gx, Gy, 1), (N - z) % N)
     XY = jacobian_multiply((x, y, 1), s)

--- a/eth_keys/exceptions.py
+++ b/eth_keys/exceptions.py
@@ -1,2 +1,6 @@
 class ValidationError(Exception):
     pass
+
+
+class BadSignature(Exception):
+    pass


### PR DESCRIPTION
Add a `BadSignature` exception that is easy for other libraries to catch.