### PR TITLE
remove incorrect validation of  signature param

### DIFF
--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -29,7 +29,6 @@ from eth_keys.exceptions import (
 )
 from eth_keys.validation import (
     validate_lt_secpk1n,
-    validate_lt_secpk1n2,
     validate_lte,
     validate_gte,
     validate_public_key_bytes,
@@ -244,7 +243,6 @@ class Signature(ByteString, BackendProxied):
         validate_integer(value)
         validate_gte(value, 0)
         validate_lt_secpk1n(value)
-        validate_lt_secpk1n2(value)
 
         self._s = value
 

--- a/eth_keys/validation.py
+++ b/eth_keys/validation.py
@@ -48,7 +48,6 @@ def validate_lte(value, maximum):
 
 
 validate_lt_secpk1n = validate_lte(maximum=SECPK1_N - 1)
-validate_lt_secpk1n2 = validate_lte(maximum=SECPK1_N // 2 - 1)
 
 
 def validate_message_hash(value):


### PR DESCRIPTION
The `s` parameter was incorrectly being validated to be `< N / 2` when this is in fact valid.