### PR TITLE
Add to_bytes api

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+* Version: x.x.x
+* Python: 2.7/3.4/3.5
+* OS: osx/linux/win
+
+
+### What was wrong?
+
+Please include any of the following that are applicable:
+
+* The code which produced the error
+* The full output of the error
+* What type of node you were connecting to.
+
+
+### How can it be fixed?
+
+Fill this section in if you know how this could or should be fixed.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,7 +9,6 @@ Please include any of the following that are applicable:
 
 * The code which produced the error
 * The full output of the error
-* What type of node you were connecting to.
 
 
 ### How can it be fixed?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What was wrong?
+
+
+
+### How was it fixed?
+
+
+
+#### Cute Animal Picture
+
+![Cute animal picture]()

--- a/README.md
+++ b/README.md
@@ -96,6 +96,22 @@ instance.
 * `private_key`: **must** be an instance of `PublicKey`
 
 
+### Common APIs for `PublicKey`, `PrivateKey` and `Signature`
+
+There is a common API for the following objects.
+
+* `PublicKey`
+* `PrivateKey`
+* `Signature`
+
+Each of these objects has all of the following APIs.
+
+* `obj.to_bytes()`: Returns the object in it's canonical `bytes` serialization.
+* `obj.to_hex()`: Returns a text string of the hex encoded canonical representation.
+* `bytes(obj)`: Same as `obj.to_bytes()`
+* `hex(obj)`: Same as `obj.to_hex()`
+
+
 ### `KeyAPI.PublicKey(public_key_bytes)`
 
 The `PublicKey` class takes a single argument which must be a bytes string with length 64.

--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -73,8 +73,11 @@ class BackendProxied(object):
 class BaseKey(ByteString, collections.Hashable):
     _raw_key = None
 
-    def _to_hex(self):
+    def to_hex(self):
         return '0x' + codecs.decode(codecs.encode(self._raw_key, 'hex'), 'ascii')
+
+    def to_bytes(self):
+        return self.__bytes__(self)
 
     def __bytes__(self):
         return self._raw_key
@@ -86,7 +89,7 @@ class BaseKey(ByteString, collections.Hashable):
         if sys.version_info.major == 2:
             return self.__bytes__()
         else:
-            return self._to_hex()
+            return self.to_hex()
 
     def __unicode__(self):
         return self.__str__()
@@ -104,16 +107,16 @@ class BaseKey(ByteString, collections.Hashable):
         return bytes(self) == bytes(other)
 
     def __repr__(self):
-        return "'{0}'".format(self._to_hex())
+        return "'{0}'".format(self.to_hex())
 
     def __index__(self):
         return self.__int__()
 
     def __hex__(self):
         if sys.version_info.major == 2:
-            return codecs.encode(self._to_hex(), 'ascii')
+            return codecs.encode(self.to_hex(), 'ascii')
         else:
-            return self._to_hex()
+            return self.to_hex()
 
 
 class PublicKey(BaseKey, BackendProxied):
@@ -252,8 +255,11 @@ class Signature(ByteString, BackendProxied):
     def vrs(self):
         return (self.v, self.r, self.s)
 
-    def _to_hex(self):
+    def to_hex(self):
         return '0x' + codecs.decode(codecs.encode(bytes(self), 'hex'), 'ascii')
+
+    def to_bytes(self):
+        return self.__bytes__(self)
 
     def __hash__(self):
         return big_endian_to_int(keccak(bytes(self)))
@@ -268,7 +274,7 @@ class Signature(ByteString, BackendProxied):
         if sys.version_info.major == 2:
             return self.__bytes__()
         else:
-            return self._to_hex()
+            return self.to_hex()
 
     def __unicode__(self):
         return self.__str__()
@@ -280,7 +286,7 @@ class Signature(ByteString, BackendProxied):
         return bytes(self)[index]
 
     def __repr__(self):
-        return "'{0}'".format(self._to_hex())
+        return "'{0}'".format(self.to_hex())
 
     def verify_msg(self, message, public_key):
         message_hash = keccak(message)
@@ -301,9 +307,9 @@ class Signature(ByteString, BackendProxied):
 
     def __hex__(self):
         if sys.version_info.major == 2:
-            return codecs.encode(self._to_hex(), 'ascii')
+            return codecs.encode(self.to_hex(), 'ascii')
         else:
-            return self._to_hex()
+            return self.to_hex()
 
     def __int__(self):
         return big_endian_to_int(bytes(self))

--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -77,7 +77,7 @@ class BaseKey(ByteString, collections.Hashable):
         return '0x' + codecs.decode(codecs.encode(self._raw_key, 'hex'), 'ascii')
 
     def to_bytes(self):
-        return self.__bytes__(self)
+        return self.__bytes__()
 
     def __bytes__(self):
         return self._raw_key
@@ -259,7 +259,7 @@ class Signature(ByteString, BackendProxied):
         return '0x' + codecs.decode(codecs.encode(bytes(self), 'hex'), 'ascii')
 
     def to_bytes(self):
-        return self.__bytes__(self)
+        return self.__bytes__()
 
     def __hash__(self):
         return big_endian_to_int(keccak(bytes(self)))

--- a/tests/core/test_key_and_signature_datastructures.py
+++ b/tests/core/test_key_and_signature_datastructures.py
@@ -121,7 +121,7 @@ def test_hex_conversion(private_key):
     assert signature.to_hex() == encode_hex(bytes(signature))
 
 
-def test_bytes_conversion(private_key)
+def test_bytes_conversion(private_key):
     public_key = private_key.public_key
     signature = private_key.sign(b'message')
 

--- a/tests/core/test_key_and_signature_datastructures.py
+++ b/tests/core/test_key_and_signature_datastructures.py
@@ -115,3 +115,20 @@ def test_hex_conversion(private_key):
     assert hex(public_key) == encode_hex(bytes(public_key))
     assert hex(private_key) == encode_hex(bytes(private_key))
     assert hex(signature) == encode_hex(bytes(signature))
+
+    assert public_key.to_hex() == encode_hex(bytes(public_key))
+    assert private_key.to_hex() == encode_hex(bytes(private_key))
+    assert signature.to_hex() == encode_hex(bytes(signature))
+
+
+def test_bytes_conversion(private_key)
+    public_key = private_key.public_key
+    signature = private_key.sign(b'message')
+
+    assert bytes(public_key) == public_key._raw_key
+    assert bytes(private_key) == private_key._raw_key
+    assert bytes(signature) == signature.__bytes__()
+
+    assert public_key.to_bytes() == public_key._raw_key
+    assert private_key.to_bytes() == private_key._raw_key
+    assert signature.to_bytes() == signature.__bytes__()


### PR DESCRIPTION
### What was wrong?

Calling `bytes(public_key)` is somewhat awkward. 

### How was it fixed.

Added a `to_bytes()` method to all of `PublicKey`, `PrivateKey` and `Signature`

![094322d7a79b7b53c28ce303ff4f753f](https://user-images.githubusercontent.com/824194/30816190-7141437a-a1d2-11e7-85b8-aded321b8ad6.jpg)
