### PR TITLE
Add type annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
   # lint
   - python: "3.5"
     env: TOX_ENV=flake8
+  # mypy
+  - python: "3.5"
+    env: TOX_ENV=mypy
   # core
   - python: "2.7"
     env: TOX_ENV=py27-core

--- a/eth_keys/backends/__init__.py
+++ b/eth_keys/backends/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import os
+from typing import Optional  # noqa: F401
 
 from eth_keys.utils.module_loading import (
     import_string,
@@ -15,6 +16,7 @@ from .native import NativeECCBackend  # noqa: F401
 
 
 def get_default_backend_class():
+    # type: () -> str
     if is_coincurve_available():
         return 'eth_keys.backends.CoinCurveECCBackend'
     else:
@@ -22,6 +24,7 @@ def get_default_backend_class():
 
 
 def get_backend_class(import_path=None):
+    # type: (Optional[str]) -> type
     if import_path is None:
         import_path = os.environ.get(
             'ECC_BACKEND_CLASS',
@@ -31,5 +34,6 @@ def get_backend_class(import_path=None):
 
 
 def get_backend(import_path=None):
+    # type: (Optional[str]) -> BaseECCBackend
     backend_class = get_backend_class(import_path)
     return backend_class()

--- a/eth_keys/backends/base.py
+++ b/eth_keys/backends/base.py
@@ -1,32 +1,37 @@
-from eth_keys.datatypes import (
-    PrivateKey,
-    PublicKey,
-    Signature,
-)
+from typing import Any  # noqa: F401
 
 
 class BaseECCBackend(object):
     def __init__(self):
+        # type: () -> None
+        from eth_keys import datatypes
+        # Mypy cannot detect the type of dynamically computed classes
+        # (https://github.com/python/mypy/issues/2477), so we must annotate those with Any
         self.PublicKey = type(
             '{0}PublicKey'.format(type(self).__name__),
-            (PublicKey,),
+            (datatypes.PublicKey,),
             {'_backend': self},
-        )
+        )  # type: Any
         self.PrivateKey = type(
             '{0}PrivateKey'.format(type(self).__name__),
-            (PrivateKey,),
+            (datatypes.PrivateKey,),
             {'_backend': self},
-        )
+        )  # type: Any
         self.Signature = type(
             '{0}Signature'.format(type(self).__name__),
-            (Signature,),
+            (datatypes.Signature,),
             {'_backend': self},
-        )
+        )  # type: Any
 
     def ecdsa_sign(self, msg_hash, private_key):
         raise NotImplementedError()
 
-    def ecdsa_verify(self, msg_hash, signature, public_key):
+    def ecdsa_verify(self,
+                     msg_hash,  # type: str
+                     signature,  # type: Signature
+                     public_key  # type: PublicKey
+                     ):
+        # type: (...) -> bool
         return self.ecdsa_recover(msg_hash, signature) == public_key
 
     def ecdsa_recover(self, msg_hash, signature):

--- a/eth_keys/backends/coincurve.py
+++ b/eth_keys/backends/coincurve.py
@@ -1,5 +1,12 @@
 from __future__ import absolute_import
 
+from typing import Optional  # noqa: F401
+
+from eth_keys.datatypes import (  # noqa: F401
+    PrivateKey,
+    PublicKey,
+    Signature,
+)
 from eth_keys.exceptions import (
     BadSignature,
 )
@@ -8,6 +15,7 @@ from .base import BaseECCBackend
 
 
 def is_coincurve_available():
+    # type: () -> bool
     try:
         import coincurve  # noqa: F401
     except ImportError:
@@ -18,6 +26,7 @@ def is_coincurve_available():
 
 class CoinCurveECCBackend(BaseECCBackend):
     def __init__(self):
+        # type: () -> None
         try:
             import coincurve
         except ImportError:
@@ -27,7 +36,11 @@ class CoinCurveECCBackend(BaseECCBackend):
         self.ecdsa = coincurve.ecdsa
         super(CoinCurveECCBackend, self).__init__()
 
-    def ecdsa_sign(self, msg_hash, private_key):
+    def ecdsa_sign(self,
+                   msg_hash,  # type: str
+                   private_key  # type: PrivateKey
+                   ):
+        # type: (...) -> Signature
         private_key_bytes = private_key.to_bytes()
         signature_bytes = self.keys.PrivateKey(private_key_bytes).sign_recoverable(
             msg_hash,
@@ -36,7 +49,11 @@ class CoinCurveECCBackend(BaseECCBackend):
         signature = self.Signature(signature_bytes)
         return signature
 
-    def ecdsa_recover(self, msg_hash, signature):
+    def ecdsa_recover(self,
+                      msg_hash,  # type: str
+                      signature  # type: Signature
+                      ):
+        # type: (...) -> Optional[PublicKey]
         signature_bytes = signature.to_bytes()
         try:
             public_key_bytes = self.keys.PublicKey.from_signature_and_message(
@@ -52,6 +69,7 @@ class CoinCurveECCBackend(BaseECCBackend):
         return public_key
 
     def private_key_to_public_key(self, private_key):
+        # type: (PrivateKey) -> PublicKey
         public_key_bytes = self.keys.PrivateKey(private_key.to_bytes()).public_key.format(
             compressed=False,
         )[1:]

--- a/eth_keys/backends/native/ecdsa.py
+++ b/eth_keys/backends/native/ecdsa.py
@@ -3,6 +3,7 @@ Functions lifted from https://github.com/vbuterin/pybitcointools
 """
 import hashlib
 import hmac
+from typing import (Callable, Optional, Tuple)  # noqa: F401
 
 from eth_utils import (
     int_to_big_endian,
@@ -41,6 +42,7 @@ def decode_public_key(public_key_bytes):
 
 
 def encode_raw_public_key(raw_public_key):
+    # type: (Tuple[int, int]) -> str
     left, right = raw_public_key
     return b''.join((
         pad32(int_to_big_endian(left)),
@@ -49,6 +51,7 @@ def encode_raw_public_key(raw_public_key):
 
 
 def private_key_to_public_key(private_key_bytes):
+    # type: (str) -> str
     private_key_as_num = big_endian_to_int(private_key_bytes)
 
     if private_key_as_num >= N:
@@ -60,6 +63,7 @@ def private_key_to_public_key(private_key_bytes):
 
 
 def deterministic_generate_k(msg_hash, private_key_bytes, digest_fn=hashlib.sha256):
+    # type: (str, str, Callable[[], hashlib._hash]) -> int
     v_0 = b'\x01' * 32
     k_0 = b'\x00' * 32
 
@@ -74,6 +78,7 @@ def deterministic_generate_k(msg_hash, private_key_bytes, digest_fn=hashlib.sha2
 
 
 def ecdsa_raw_sign(msg_hash, private_key_bytes):
+    # type: (str, str) -> Tuple[int, int, int]
     z = big_endian_to_int(msg_hash)
     k = deterministic_generate_k(msg_hash, private_key_bytes)
 
@@ -106,6 +111,7 @@ def ecdsa_raw_verify(msg_hash, vrs, public_key_bytes):
 
 
 def ecdsa_raw_recover(msg_hash, vrs):
+    # type: (str, Tuple[int, int, int]) -> Optional[str]
     v, r, s = vrs
     v += 27
 
@@ -126,6 +132,6 @@ def ecdsa_raw_recover(msg_hash, vrs):
     XY = jacobian_multiply((x, y, 1), s)
     Qr = jacobian_add(Gz, XY)
     Q = jacobian_multiply(Qr, inv(r, N))
-    Q = from_jacobian(Q)
+    raw_public_key = from_jacobian(Q)
 
-    return encode_raw_public_key(Q)
+    return encode_raw_public_key(raw_public_key)

--- a/eth_keys/backends/native/jacobian.py
+++ b/eth_keys/backends/native/jacobian.py
@@ -1,3 +1,5 @@
+from typing import Tuple  # noqa: F401
+
 from eth_keys.constants import (
     SECPK1_P as P,
     SECPK1_N as N,
@@ -6,6 +8,7 @@ from eth_keys.constants import (
 
 
 def inv(a, n):
+    # type: (int, int) -> int
     if a == 0:
         return 0
     lm, hm = 1, 0
@@ -18,11 +21,13 @@ def inv(a, n):
 
 
 def to_jacobian(p):
+    # type: (Tuple[int, int]) -> Tuple[int, int, int]
     o = (p[0], p[1], 1)
     return o
 
 
 def jacobian_double(p):
+    # type: (Tuple[int, int, int]) -> Tuple[int, int, int]
     if not p[1]:
         return (0, 0, 0)
     ysq = (p[1] ** 2) % P
@@ -34,7 +39,10 @@ def jacobian_double(p):
     return (nx, ny, nz)
 
 
-def jacobian_add(p, q):
+def jacobian_add(p,  # type: Tuple[int, int, int]
+                 q  # type: Tuple[int, int, int]
+                 ):
+    # type: (...) -> Tuple[int, int, int]
     if not p[1]:
         return q
     if not q[1]:
@@ -59,11 +67,13 @@ def jacobian_add(p, q):
 
 
 def from_jacobian(p):
+    # type: (Tuple[int, int, int]) -> Tuple[int, int]
     z = inv(p[2], P)
     return ((p[0] * z**2) % P, (p[1] * z**3) % P)
 
 
 def jacobian_multiply(a, n):
+    # type: (Tuple[int, int, int], int) -> Tuple[int, int, int]
     if a[1] == 0 or n == 0:
         return (0, 0, 1)
     if n == 1:
@@ -72,11 +82,14 @@ def jacobian_multiply(a, n):
         return jacobian_multiply(a, n % N)
     if (n % 2) == 0:
         return jacobian_double(jacobian_multiply(a, n // 2))
-    if (n % 2) == 1:
+    elif (n % 2) == 1:
         return jacobian_add(jacobian_double(jacobian_multiply(a, n // 2)), a)
+    else:
+        raise Exception("Invariant: Unreachable code path")
 
 
 def fast_multiply(a, n):
+    # type: (Tuple[int, int], int) -> Tuple[int, int]
     return from_jacobian(jacobian_multiply(to_jacobian(a), n))
 
 

--- a/eth_keys/backends/native/main.py
+++ b/eth_keys/backends/native/main.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+from typing import Optional  # noqa: F401
+
 from .ecdsa import (
     ecdsa_raw_recover,
     ecdsa_raw_sign,
@@ -7,20 +9,31 @@ from .ecdsa import (
 )
 
 from eth_keys.backends.base import BaseECCBackend
+from eth_keys.datatypes import (  # noqa: F401
+    PrivateKey,
+    PublicKey,
+    Signature,
+)
 
 
 class NativeECCBackend(BaseECCBackend):
     def ecdsa_sign(self, msg_hash, private_key):
+        # type: (str, PrivateKey) -> Signature
         signature_vrs = ecdsa_raw_sign(msg_hash, private_key.to_bytes())
         signature = self.Signature(vrs=signature_vrs)
         return signature
 
-    def ecdsa_recover(self, msg_hash, signature):
+    def ecdsa_recover(self,
+                      msg_hash,  # type: str
+                      signature  # type: Signature
+                      ):
+        # type: (...) -> Optional[PublicKey]
         public_key_bytes = ecdsa_raw_recover(msg_hash, signature.vrs)
         public_key = self.PublicKey(public_key_bytes)
         return public_key
 
     def private_key_to_public_key(self, private_key):
+        # type: (PrivateKey) -> PublicKey
         public_key_bytes = private_key_to_public_key(private_key.to_bytes())
         public_key = self.PublicKey(public_key_bytes)
         return public_key

--- a/eth_keys/main.py
+++ b/eth_keys/main.py
@@ -1,3 +1,5 @@
+from typing import (Any, Optional, Union)  # noqa: F401
+
 from eth_utils import (
     is_string,
 )
@@ -64,11 +66,17 @@ class KeyAPI(object):
     #
     # Proxy method calls to the backends
     #
-    PublicKey = backend_property_proxy('PublicKey')  # noqa: F811
-    PrivateKey = backend_property_proxy('PrivateKey')  # noqa: F811
-    Signature = backend_property_proxy('Signature')  # noqa: F811
+    # Mypy cannot detect the type of dynamically computed classes
+    # (https://github.com/python/mypy/issues/2477), so we must annotate those with Any
+    PublicKey = backend_property_proxy('PublicKey')  # type: Any
+    PrivateKey = backend_property_proxy('PrivateKey')  # type: Any
+    Signature = backend_property_proxy('Signature')  # type: Any
 
-    def ecdsa_sign(self, message_hash, private_key):
+    def ecdsa_sign(self,
+                   message_hash,  # type: str
+                   private_key  # type: Union[PrivateKey, str]
+                   ):
+        # type: (...) -> Optional[Signature]
         validate_message_hash(message_hash)
         if not isinstance(private_key, PrivateKey):
             raise ValidationError(
@@ -82,14 +90,23 @@ class KeyAPI(object):
             )
         return signature
 
-    def ecdsa_verify(self, message_hash, signature, public_key):
+    def ecdsa_verify(self,
+                     message_hash,  # type: str
+                     signature,  # type: Union[Signature, str]
+                     public_key  # type: Union[PublicKey, str]
+                     ):
+        # type: (...) -> Optional[bool]
         if not isinstance(public_key, PublicKey):
             raise ValidationError(
                 "The `public_key` must be an instance of `eth_keys.datatypes.PublicKey`"
             )
         return self.ecdsa_recover(message_hash, signature) == public_key
 
-    def ecdsa_recover(self, message_hash, signature):
+    def ecdsa_recover(self,
+                      message_hash,  # type: str
+                      signature  # type: Union[Signature, str]
+                      ):
+        # type: (...) -> Optional[PublicKey]
         validate_message_hash(message_hash)
         if not isinstance(signature, Signature):
             raise ValidationError(

--- a/eth_keys/utils/address.py
+++ b/eth_keys/utils/address.py
@@ -4,4 +4,5 @@ from eth_utils import (
 
 
 def public_key_bytes_to_address(public_key_bytes):
+    # type: (str) -> str
     return keccak(public_key_bytes)[-20:]

--- a/eth_keys/utils/module_loading.py
+++ b/eth_keys/utils/module_loading.py
@@ -3,6 +3,7 @@ from importlib import import_module
 
 
 def import_string(dotted_path):
+    # type: (str) -> type
     """
     Source: django.utils.module_loading
     Import a dotted module path and return the attribute/class designated by the

--- a/eth_keys/validation.py
+++ b/eth_keys/validation.py
@@ -16,17 +16,20 @@ from eth_keys.exceptions import (
 
 
 def validate_integer(value):
+    # type: (int) -> None
     if not is_integer(value) or isinstance(value, bool):
         raise ValidationError("Value must be a an integer.  Got: {0}".format(type(value)))
 
 
 def validate_bytes(value):
+    # type: (str) -> None
     if not is_bytes(value):
         raise ValidationError("Value must be a byte string.  Got: {0}".format(type(value)))
 
 
 @curry
 def validate_gte(value, minimum):
+    # type: (int, int) -> None
     validate_integer(value)
     if value < minimum:
         raise ValidationError(
@@ -38,6 +41,7 @@ def validate_gte(value, minimum):
 
 @curry
 def validate_lte(value, maximum):
+    # type: (int, int) -> None
     validate_integer(value)
     if value > maximum:
         raise ValidationError(
@@ -51,24 +55,28 @@ validate_lt_secpk1n = validate_lte(maximum=SECPK1_N - 1)
 
 
 def validate_message_hash(value):
+    # type: (str) -> None
     validate_bytes(value)
     if len(value) != 32:
         raise ValidationError("Unexpected signature format.  Must be length 65 byte string")
 
 
 def validate_public_key_bytes(value):
+    # type: (str) -> None
     validate_bytes(value)
     if len(value) != 64:
         raise ValidationError("Unexpected public key format.  Must be length 64 byte string")
 
 
 def validate_private_key_bytes(value):
+    # type: (str) -> None
     validate_bytes(value)
     if len(value) != 32:
         raise ValidationError("Unexpected private key format.  Must be length 32 byte string")
 
 
 def validate_signature_bytes(value):
+    # type: (str) -> None
     validate_bytes(value)
     if len(value) != 65:
         raise ValidationError("Unexpected signature format.  Must be length 65 byte string")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest==3.2.2
 tox==1.8.0
 flake8==3.0.4
 hypothesis==3.30.0
+typing==3.6.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+
+# Change COLLECT_TYPE_INFO to True here, and run the tests with python2.7 to get a type info dump
+# that can later be fed to pyannotate to generate type annotation comments.
+COLLECT_TYPE_INFO = False
+
+if COLLECT_TYPE_INFO:
+    from pyannotate_runtime import collect_types
+
+    @pytest.fixture(autouse=True)
+    def collect_types_fixture():
+        collect_types.resume()
+        yield
+        collect_types.pause()
+
+
+    def pytest_sessionstart(session):
+        collect_types.init_types_collection()
+
+
+    def pytest_sessionfinish(session, exitstatus):
+        collect_types.dump_stats("type_info.json")

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist=
     py{27,34,35}-{core,backends}
     flake8
+    mypy
 
 [flake8]
 max-line-length= 100
@@ -26,3 +27,9 @@ basepython =
 basepython=python
 deps=flake8
 commands=flake8 {toxinidir}/eth_keys
+
+[testenv:mypy]
+basepython=python3.5
+deps=mypy
+# TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
+commands=mypy --py2 --ignore-missing-imports {toxinidir}/eth_keys


### PR DESCRIPTION
This branch includes a pytest fixture that uses pyannotate to dump a json file with type information.

Once you feed that to pyannotate it will generate the type annotation comments seen in the diff here, although I had to modify some of them for various reasons (that is expected).

With those comments we can use mypy to perform static type checking, like this:

> $ mypy --py2 eth_keys/main.py