### PR TITLE
Type annotations: use bytes instead of str

### DIFF
--- a/eth_keys/backends/base.py
+++ b/eth_keys/backends/base.py
@@ -27,7 +27,7 @@ class BaseECCBackend(object):
         raise NotImplementedError()
 
     def ecdsa_verify(self,
-                     msg_hash,  # type: str
+                     msg_hash,   # type: bytes
                      signature,  # type: Signature
                      public_key  # type: PublicKey
                      ):

--- a/eth_keys/backends/native/ecdsa.py
+++ b/eth_keys/backends/native/ecdsa.py
@@ -3,7 +3,7 @@ Functions lifted from https://github.com/vbuterin/pybitcointools
 """
 import hashlib
 import hmac
-from typing import (Callable, Optional, Tuple)  # noqa: F401
+from typing import (Any, Callable, Optional, Tuple)  # noqa: F401
 
 from eth_utils import (
     int_to_big_endian,
@@ -42,7 +42,7 @@ def decode_public_key(public_key_bytes):
 
 
 def encode_raw_public_key(raw_public_key):
-    # type: (Tuple[int, int]) -> str
+    # type: (Tuple[int, int]) -> bytes
     left, right = raw_public_key
     return b''.join((
         pad32(int_to_big_endian(left)),
@@ -51,7 +51,7 @@ def encode_raw_public_key(raw_public_key):
 
 
 def private_key_to_public_key(private_key_bytes):
-    # type: (str) -> str
+    # type: (bytes) -> bytes
     private_key_as_num = big_endian_to_int(private_key_bytes)
 
     if private_key_as_num >= N:
@@ -63,7 +63,7 @@ def private_key_to_public_key(private_key_bytes):
 
 
 def deterministic_generate_k(msg_hash, private_key_bytes, digest_fn=hashlib.sha256):
-    # type: (str, str, Callable[[], hashlib._hash]) -> int
+    # type: (bytes, bytes, Callable[[], Any]) -> int
     v_0 = b'\x01' * 32
     k_0 = b'\x00' * 32
 
@@ -78,7 +78,7 @@ def deterministic_generate_k(msg_hash, private_key_bytes, digest_fn=hashlib.sha2
 
 
 def ecdsa_raw_sign(msg_hash, private_key_bytes):
-    # type: (str, str) -> Tuple[int, int, int]
+    # type: (bytes, bytes) -> Tuple[int, int, int]
     z = big_endian_to_int(msg_hash)
     k = deterministic_generate_k(msg_hash, private_key_bytes)
 
@@ -92,6 +92,7 @@ def ecdsa_raw_sign(msg_hash, private_key_bytes):
 
 
 def ecdsa_raw_verify(msg_hash, vrs, public_key_bytes):
+    # type: (bytes, Tuple[int, int, int], bytes) -> Optional[bool]
     raw_public_key = decode_public_key(public_key_bytes)
 
     v, r, s = vrs
@@ -111,7 +112,7 @@ def ecdsa_raw_verify(msg_hash, vrs, public_key_bytes):
 
 
 def ecdsa_raw_recover(msg_hash, vrs):
-    # type: (str, Tuple[int, int, int]) -> Optional[str]
+    # type: (bytes, Tuple[int, int, int]) -> Optional[bytes]
     v, r, s = vrs
     v += 27
 

--- a/eth_keys/backends/native/main.py
+++ b/eth_keys/backends/native/main.py
@@ -18,13 +18,13 @@ from eth_keys.datatypes import (  # noqa: F401
 
 class NativeECCBackend(BaseECCBackend):
     def ecdsa_sign(self, msg_hash, private_key):
-        # type: (str, PrivateKey) -> Signature
+        # type: (bytes, PrivateKey) -> Signature
         signature_vrs = ecdsa_raw_sign(msg_hash, private_key.to_bytes())
         signature = self.Signature(vrs=signature_vrs)
         return signature
 
     def ecdsa_recover(self,
-                      msg_hash,  # type: str
+                      msg_hash,  # type: bytes
                       signature  # type: Signature
                       ):
         # type: (...) -> Optional[PublicKey]

--- a/eth_keys/main.py
+++ b/eth_keys/main.py
@@ -73,8 +73,8 @@ class KeyAPI(object):
     Signature = backend_property_proxy('Signature')  # type: Any
 
     def ecdsa_sign(self,
-                   message_hash,  # type: str
-                   private_key  # type: Union[PrivateKey, str]
+                   message_hash,  # type: bytes
+                   private_key  # type: Union[PrivateKey, bytes]
                    ):
         # type: (...) -> Optional[Signature]
         validate_message_hash(message_hash)
@@ -91,9 +91,9 @@ class KeyAPI(object):
         return signature
 
     def ecdsa_verify(self,
-                     message_hash,  # type: str
-                     signature,  # type: Union[Signature, str]
-                     public_key  # type: Union[PublicKey, str]
+                     message_hash,  # type: bytes
+                     signature,  # type: Union[Signature, bytes]
+                     public_key  # type: Union[PublicKey, bytes]
                      ):
         # type: (...) -> Optional[bool]
         if not isinstance(public_key, PublicKey):
@@ -103,8 +103,8 @@ class KeyAPI(object):
         return self.ecdsa_recover(message_hash, signature) == public_key
 
     def ecdsa_recover(self,
-                      message_hash,  # type: str
-                      signature  # type: Union[Signature, str]
+                      message_hash,  # type: bytes
+                      signature  # type: Union[Signature, bytes]
                       ):
         # type: (...) -> Optional[PublicKey]
         validate_message_hash(message_hash)

--- a/eth_keys/utils/address.py
+++ b/eth_keys/utils/address.py
@@ -4,5 +4,5 @@ from eth_utils import (
 
 
 def public_key_bytes_to_address(public_key_bytes):
-    # type: (str) -> str
+    # type: (bytes) -> bytes
     return keccak(public_key_bytes)[-20:]

--- a/eth_keys/validation.py
+++ b/eth_keys/validation.py
@@ -22,7 +22,7 @@ def validate_integer(value):
 
 
 def validate_bytes(value):
-    # type: (str) -> None
+    # type: (bytes) -> None
     if not is_bytes(value):
         raise ValidationError("Value must be a byte string.  Got: {0}".format(type(value)))
 
@@ -55,28 +55,28 @@ validate_lt_secpk1n = validate_lte(maximum=SECPK1_N - 1)
 
 
 def validate_message_hash(value):
-    # type: (str) -> None
+    # type: (bytes) -> None
     validate_bytes(value)
     if len(value) != 32:
         raise ValidationError("Unexpected signature format.  Must be length 65 byte string")
 
 
 def validate_public_key_bytes(value):
-    # type: (str) -> None
+    # type: (bytes) -> None
     validate_bytes(value)
     if len(value) != 64:
         raise ValidationError("Unexpected public key format.  Must be length 64 byte string")
 
 
 def validate_private_key_bytes(value):
-    # type: (str) -> None
+    # type: (bytes) -> None
     validate_bytes(value)
     if len(value) != 32:
         raise ValidationError("Unexpected private key format.  Must be length 32 byte string")
 
 
 def validate_signature_bytes(value):
-    # type: (str) -> None
+    # type: (bytes) -> None
     validate_bytes(value)
     if len(value) != 65:
         raise ValidationError("Unexpected signature format.  Must be length 65 byte string")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest==3.2.2
-tox==1.8.0
+tox==2.7.0
 flake8==3.0.4
 hypothesis==3.30.0
 typing==3.6.2

--- a/tox.ini
+++ b/tox.ini
@@ -32,4 +32,6 @@ commands=flake8 {toxinidir}/eth_keys
 basepython=python3.5
 deps=mypy
 # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
-commands=mypy --py2 --ignore-missing-imports {toxinidir}/eth_keys
+commands=
+    mypy --py2 --ignore-missing-imports {toxinidir}/eth_keys
+    mypy --ignore-missing-imports {toxinidir}/eth_keys


### PR DESCRIPTION
That way we can use mypy to type check for py3 as well as py2.