### PR TITLE
bumpversion/github migration/python2 deprecation

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,23 @@
+[bumpversion]
+current_version = 0.7.1
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-{stage}.{devnum}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:stage]
+optional_value = stable
+first_value = stable
+values = 
+	alpha
+	beta
+	stable
+
+[bumpversion:part:devnum]
+
+[bumpversion:file:setup.py]
+search = version='{current_version}',
+replace = version='{new_version}',
+

--- a/README.md
+++ b/README.md
@@ -7,8 +7,67 @@ A common API for Ethereum key operations with pluggable backends.
 ## Installation
 
 ```sh
-pip install ethereum-keys
+pip install eth-keys
 ```
+
+## Development
+
+```sh
+pip install -e . -r requirements-dev.txt
+```
+
+
+### Running the tests
+
+You can run the tests with:
+
+```sh
+py.test tests
+```
+
+Or you can install `tox` to run the full test suite.
+
+
+### Releasing
+
+Pandoc is required for transforming the markdown README to the proper format to
+render correctly on pypi.
+
+For Debian-like systems:
+
+```
+apt install pandoc
+```
+
+Or on OSX:
+
+```sh
+brew install pandoc
+```
+
+To release a new version:
+
+```sh
+bumpversion $$VERSION_PART_TO_BUMP$$
+git push && git push --tags
+make release
+```
+
+
+#### How to bumpversion
+
+The version format for this repo is `{major}.{minor}.{patch}` for stable, and
+`{major}.{minor}.{patch}-{stage}.{devnum}` for unstable (`stage` can be alpha or beta).
+
+To issue the next version in line, use bumpversion and specify which part to bump,
+like `bumpversion minor` or `bumpversion devnum`.
+
+If you are in a beta version, `bumpversion stage` will switch to a stable.
+
+To issue an unstable version when the current version is stable, specify the
+new version explicitly, like `bumpversion --new-version 4.0.0-alpha.1 devnum`
+
+
 
 ## QuickStart
 
@@ -35,7 +94,7 @@ True
 
 ### `KeyAPI(backend=None)`
 
-The `KeyAPI` object is the primary API for interacting with the `ethereum-keys`
+The `KeyAPI` object is the primary API for interacting with the `eth-keys`
 libary.  The object takes a single optional argument in it's constructor which
 designates what backend will be used for eliptical curve cryptography
 operations.  The built-in backends are:
@@ -43,11 +102,11 @@ operations.  The built-in backends are:
 * `eth_keys.backends.NativeECCBackend` A pure python implementation of the ECC operations.
 * `eth_keys.backends.CoinCurveECCBackend`: Uses the [`coincurve`](https://github.com/ofek/coincurve) library for ECC operations.
 
-By default, `ethereum-keys` will *try* to use the `CoinCurveECCBackend`,
+By default, `eth-keys` will *try* to use the `CoinCurveECCBackend`,
 falling back to the `NativeECCBackend` if the `coincurve` library is not
 available.
 
-> Note: The `coincurve` library is not automatically installed with `ethereum-keys` and must be installed separately.
+> Note: The `coincurve` library is not automatically installed with `eth-keys` and must be installed separately.
 
 The `backend` argument can be given in any of the following forms.
 

--- a/eth_keys/__init__.py
+++ b/eth_keys/__init__.py
@@ -1,5 +1,17 @@
 from __future__ import absolute_import
 
+import sys
+import warnings
+
+
+if sys.version_info.major < 3:
+    warnings.simplefilter('always', DeprecationWarning)
+    warnings.warn(DeprecationWarning(
+        "The `eth-keys` library is dropping support for Python 2.  Upgrade to Python 3."
+    ))
+    warnings.resetwarnings()
+
+
 from .main import (  # noqa: F401
     KeyAPI,
     lazy_key_api as keys,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest==3.2.2
 tox==1.8.0
 flake8==3.0.4
 hypothesis==3.30.0
+bumpversion==0.5.3

--- a/setup.py
+++ b/setup.py
@@ -12,17 +12,18 @@ DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 setup(
-    name='ethereum-keys',
+    name='eth-keys',
+    # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version='0.1.0-alpha.7',
     description="""Common API for Ethereum key operations.""",
     long_description_markdown_filename='README.md',
     author='Piper Merriam',
     author_email='pipermerriam@gmail.com',
-    url='https://github.com/pipermerriam/ethereum-keys',
+    url='https://github.com/ethereum/eth-keys',
     include_package_data=True,
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "ethereum-utils>=0.4.0",
+        "eth-utils>=0.5.0",
         "cytoolz>=0.8.2",
     ],
     py_modules=['eth_keys'],


### PR DESCRIPTION
### What was wrong?

Needed to make some changes to accommodate the move of the library.

### How was it fixed?

* Renamed to `eth-keys`
* Updated `eth-utils` dependency library name.
* Deprecation warning for python 2
* Bumpversion

#### Cute Animal Picture

![09a67b6ca3459517ec3b7958044bb530](https://user-images.githubusercontent.com/824194/33288362-3aa9676a-d379-11e7-8232-71e78248ba4c.jpg)

