### PR TITLE
Handle missing typing dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,4 @@ pytest==3.2.2
 tox==2.7.0
 flake8==3.0.4
 hypothesis==3.30.0
-typing==3.6.2
 bumpversion==0.5.3

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,22 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
-
 from setuptools import (
     setup,
     find_packages,
 )
 
 
-DIR = os.path.dirname(os.path.abspath(__file__))
+install_requires=[
+    "eth-utils>=0.5.0",
+    "cytoolz>=0.8.2",
+]
+
+
+try:
+    import typing
+except ImportError:
+    # python 2 and 3.4 support
+    install_requires.append("typing==3.6.2")
 
 
 setup(
@@ -22,10 +30,7 @@ setup(
     url='https://github.com/ethereum/eth-keys',
     include_package_data=True,
     setup_requires=['setuptools-markdown'],
-    install_requires=[
-        "eth-utils>=0.5.0",
-        "cytoolz>=0.8.2",
-    ],
+    install_requires=install_requires,
     py_modules=['eth_keys'],
     license="MIT",
     zip_safe=False,


### PR DESCRIPTION
### What was wrong?

Python 2 and 3.4 don't have the `typing` module

### How was it fixed?

Conditionally install the backport.

#### Cute Animal Picture

![15cb1f66e4f0f411baff8afdb17d8d4c--basset-hound-puppy-bassett-hound-puppies](https://user-images.githubusercontent.com/824194/33291471-25c3efbe-d383-11e7-89a9-53175f8da3ae.jpg)
