### PR TITLE
more stringent requirements declarations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ matrix:
     env: TOX_ENV=py34-core
   - python: "3.5"
     env: TOX_ENV=py35-core
+  - python: "3.6"
+    env: TOX_ENV=py36-core
   # backends
   - python: "2.7"
     env: TOX_ENV=py27-backends
@@ -32,6 +34,8 @@ matrix:
     env: TOX_ENV=py34-backends
   - python: "3.5"
     env: TOX_ENV=py35-backends
+  - python: "3.6"
+    env: TOX_ENV=py36-backends
 cache:
   pip: true
 install:

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,10 @@ setup(
     include_package_data=True,
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-utils>=0.5.0",
-        "cytoolz>=0.8.2",
+        "eth-utils>=0.5.0<1.0.0",
+        "cytoolz>=0.9.0,<1.0.0",
         # can be removed when py27/34 are removed.
-        "typing==3.6.2",
+        "typing>=3.6.2,<4.0.0;python_version<'3.5'",
     ],
     py_modules=['eth_keys'],
     license="MIT",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35}-{core,backends}
+    py{27,34,35,36}-{core,backends}
     flake8
     mypy
 
@@ -22,6 +22,7 @@ basepython =
     py27: python2.7
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
### What was wrong?

Requirements were predominantly declared using `>=` which allows for major version bumps to be automatically installed.

### How was it fixed?

Added extra `<` for major version.

#### Cute Animal Picture

![baby-english-springer-spaniel](https://user-images.githubusercontent.com/824194/34307087-a261ac12-e703-11e7-9aee-16ac069715d2.jpg)
