### PR TITLE
Fixed mistaken use of public_key in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ to the desired backend.
 ### `KeyAPI.ecdsa_sign(message_hash, private_key) -> Signature`
 
 This method returns a signature for the given `message_hash`, signed by the
-provided `public_key`.
+provided `private_key`.
 
 * `message_hash`: **must** be a byte string of length 32
 * `private_key`: **must** be an instance of `PrivateKey`


### PR DESCRIPTION
### What was wrong?

The description of `KeyAPI.ecdsa_sign` mistakenly said the message_hash is signed using the `public_key` instead of the `private_key`

### How was it fixed?

README edited.

#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/926653/34905197-9d224f62-f85c-11e7-8667-a5634e17d668.jpg)
