### PR TITLE
Separate eth-utils version range with a comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-utils>=0.5.0<1.0.0",
+        "eth-utils>=0.5.0,<1.0.0",
         "cytoolz>=0.9.0,<1.0.0",
         # can be removed when py27/34 are removed.
         "typing>=3.6.2,<4.0.0;python_version<'3.5'",


### PR DESCRIPTION
### What was wrong?

#30 eth-utils dependency doesn't separate the low end and the high end of the versions with a comma. Technically it works with the latest setuputils (apparently), but it's more standard and easy to read with a comma, anyway.

### How was it fixed?

Added a comma

#### Cute Animal Picture

![Cute animal picture](https://pre00.deviantart.net/f115/th/pre/f/2013/143/1/5/commas_3inarow_by_destro7000-d66a57a.jpg)