### PR TITLE
upgrade eth-utils to v1-beta, drop py2 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.egg-info
 dist
 build
+.eggs
 eggs
 parts
 bin
@@ -17,6 +18,7 @@ develop-eggs
 .installed.cfg
 lib
 lib64
+venv
 
 # Installer logs
 pip-log.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
   - python: "3.5"
     env: TOX_ENV=mypy
   # core
-  - python: "2.7"
-    env: TOX_ENV=py27-core
   - python: "3.4"
     env: TOX_ENV=py34-core
   - python: "3.5"
@@ -28,8 +26,6 @@ matrix:
   - python: "3.6"
     env: TOX_ENV=py36-core
   # backends
-  - python: "2.7"
-    env: TOX_ENV=py27-backends
   - python: "3.4"
     env: TOX_ENV=py34-backends
   - python: "3.5"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-utils>=0.5.0,<1.0.0",
+        "eth-utils>=1.0.0-beta.1,<2.0.0",
         "cytoolz>=0.9.0,<1.0.0",
         # can be removed when py27/34 are removed.
         "typing>=3.6.2,<4.0.0;python_version<'3.5'",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35,36}-{core,backends}
+    py{34,35,36}-{core,backends}
     flake8
     mypy
 
@@ -19,7 +19,6 @@ deps =
 setenv =
     backends: REQUIRE_COINCURVE=True
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
### What was wrong?

eth-account needs to use eth-keys & eth-utils v1-beta

### How was it fixed?

-added v1-beta
-dropped py2 support

#### Cute Animal Picture

![Cute animal picture](https://data.whicdn.com/images/34042698/original.jpg)