### PR TITLE
Update usage of eth-utils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,21 +13,25 @@ addons:
 matrix:
   include:
   # lint
-  - python: "3.5"
+  - python: "3.6"
     env: TOX_ENV=flake8
   # mypy
-  - python: "3.5"
+  - python: "3.6"
     env: TOX_ENV=mypy
   # core
   - python: "3.5"
     env: TOX_ENV=py35-core
   - python: "3.6"
     env: TOX_ENV=py36-core
+  #- python: "pypy3"
+  #- env: TOX_ENV=pypy3-core
   # backends
   - python: "3.5"
     env: TOX_ENV=py35-backends
   - python: "3.6"
     env: TOX_ENV=py36-backends
+  #- python: "pypy3"
+  #- env: TOX_ENV=pypy3-backends
 cache:
   pip: true
 install:

--- a/eth_keys/utils/padding.py
+++ b/eth_keys/utils/padding.py
@@ -1,10 +1,2 @@
-from cytoolz import (
-    partial,
-)
-
-from eth_utils import (
-    pad_left,
-)
-
-
-pad32 = partial(pad_left, to_size=32, pad_with=b'\x00')
+def pad32(value):
+    return value.rjust(32, b'\x00')

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     include_package_data=True,
     setup_requires=['setuptools-markdown'],
     install_requires=[
-        "eth-utils>=1.0.0-beta.1,<2.0.0",
+        "eth-utils>=1.0.0-beta.2,<2.0.0",
         "cytoolz>=0.9.0,<1.0.0",
     ],
     py_modules=['eth_keys'],

--- a/tests/backends/conftest.py
+++ b/tests/backends/conftest.py
@@ -34,9 +34,9 @@ for secret in ['alice', 'bob', 'eve']:
 
 SECRETS = {
     "alice": dict(
-        privkey=decode_hex(b'9c0257114eb9399a2985f8e75dad7600c5d89fe3824ffa99ec1c3eb8bf3b0501'),
-        pubkey=decode_hex(b'5eed5fa3a67696c334762bb4823e585e2ee579aba3558d9955296d6c04541b426078dbd48d74af1fd0c72aa1a05147cf17be6b60bdbed6ba19b08ec28445b0ca'),  # noqa: E501
-        sig=decode_hex(b'b20e2ea5d3cbaa83c1e0372f110cf12535648613b479b64c1a8c1a20c5021f380434d07ec5795e3f789794351658e80b7faf47a46328f41e019d7b853745cdfd01'),  # noqa: E501
+        privkey=decode_hex('0x9c0257114eb9399a2985f8e75dad7600c5d89fe3824ffa99ec1c3eb8bf3b0501'),
+        pubkey=decode_hex('0x5eed5fa3a67696c334762bb4823e585e2ee579aba3558d9955296d6c04541b426078dbd48d74af1fd0c72aa1a05147cf17be6b60bdbed6ba19b08ec28445b0ca'),  # noqa: E501
+        sig=decode_hex('0xb20e2ea5d3cbaa83c1e0372f110cf12535648613b479b64c1a8c1a20c5021f380434d07ec5795e3f789794351658e80b7faf47a46328f41e019d7b853745cdfd01'),  # noqa: E501
         raw_sig=(
             1,
             80536744857756143861726945576089915884233437828013729338039544043241440681784,
@@ -44,9 +44,9 @@ SECRETS = {
         )
     ),
     "bob": dict(
-        privkey=decode_hex(b'38e47a7b719dce63662aeaf43440326f551b8a7ee198cee35cb5d517f2d296a2'),
-        pubkey=decode_hex(b'347746ccb908e583927285fa4bd202f08e2f82f09c920233d89c47c79e48f937d049130e3d1c14cf7b21afefc057f71da73dec8e8ff74ff47dc6a574ccd5d570'),  # noqa: E501
-        sig=decode_hex(b'5c48ea4f0f2257fa23bd25e6fcb0b75bbe2ff9bbda0167118dab2bb6e31ba76e691dbdaf2a231fc9958cd8edd99507121f8184042e075cf10f98ba88abff1f3601'),  # noqa: E501
+        privkey=decode_hex('0x38e47a7b719dce63662aeaf43440326f551b8a7ee198cee35cb5d517f2d296a2'),
+        pubkey=decode_hex('0x347746ccb908e583927285fa4bd202f08e2f82f09c920233d89c47c79e48f937d049130e3d1c14cf7b21afefc057f71da73dec8e8ff74ff47dc6a574ccd5d570'),  # noqa: E501
+        sig=decode_hex('0x5c48ea4f0f2257fa23bd25e6fcb0b75bbe2ff9bbda0167118dab2bb6e31ba76e691dbdaf2a231fc9958cd8edd99507121f8184042e075cf10f98ba88abff1f3601'),  # noqa: E501
         raw_sig=(
             1,
             41741612198399299636429810387160790514780876799439767175315078161978521003886,
@@ -54,9 +54,9 @@ SECRETS = {
         ),
     ),
     "eve": dict(
-        privkey=decode_hex(b'876be0999ed9b7fc26f1b270903ef7b0c35291f89407903270fea611c85f515c'),
-        pubkey=decode_hex(b'c06641f0d04f64dba13eac9e52999f2d10a1ff0ca68975716b6583dee0318d91e7c2aed363ed22edeba2215b03f6237184833fd7d4ad65f75c2c1d5ea0abecc0'),  # noqa: E501
-        sig=decode_hex(b'babeefc5082d3ca2e0bc80532ab38f9cfb196fb9977401b2f6a98061f15ed603603d0af084bf906b2cdf6cdde8b2e1c3e51a41af5e9adec7f3643b3f1aa2aadf00'),  # noqa: E501
+        privkey=decode_hex('0x876be0999ed9b7fc26f1b270903ef7b0c35291f89407903270fea611c85f515c'),
+        pubkey=decode_hex('0xc06641f0d04f64dba13eac9e52999f2d10a1ff0ca68975716b6583dee0318d91e7c2aed363ed22edeba2215b03f6237184833fd7d4ad65f75c2c1d5ea0abecc0'),  # noqa: E501
+        sig=decode_hex('0xbabeefc5082d3ca2e0bc80532ab38f9cfb196fb9977401b2f6a98061f15ed603603d0af084bf906b2cdf6cdde8b2e1c3e51a41af5e9adec7f3643b3f1aa2aadf00'),  # noqa: E501
         raw_sig=(
             0,
             84467545608142925331782333363288012579669270632210954476013542647119929595395,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{35,36}-{core,backends}
+    py{35,36,py3}-{core,backends}
     flake8
     mypy
 
@@ -15,12 +15,14 @@ commands=
     backends: py.test {posargs:tests/backends}
 deps =
     -r{toxinidir}/requirements-dev.txt
-    backends: coincurve
+    pycryptodome>=3.4.11,<4.0.0
+    backends: coincurve>=7.0.0,<8.0.0
 setenv =
     backends: REQUIRE_COINCURVE=True
 basepython =
     py35: python3.5
     py36: python3.6
+    pypy3: pypy3
 
 [testenv:flake8]
 basepython=python
@@ -28,7 +30,7 @@ deps=flake8
 commands=flake8 {toxinidir}/eth_keys
 
 [testenv:mypy]
-basepython=python3.5
+basepython=python3.6
 deps=mypy
 setenv=MYPYPATH={toxinidir}
 # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz


### PR DESCRIPTION
### What was wrong?

This libary used some of the `eth-utils` functions which have either been deprecated, or had breaking changes.

### How was it fixed?

- removed usage of `left_pad` in favor of built-in `str.rjust`
- changed usage of `decode_hex` to use `0x` prefixed text strings.

#### Cute Animal Picture

![_47242706_dpp_0006](https://user-images.githubusercontent.com/824194/36441893-31dcc4c4-1631-11e8-9d34-94e304336ef2.jpg)
