### PR TITLE
let eth-hash manage the backend versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,85 @@
+version: 2.0
+
+# heavily inspired by https://raw.githubusercontent.com/pinax/pinax-wiki/6bd2a99ab6f702e300d708532a6d1d9aa638b9f8/.circleci/config.yml
+
+common: &common
+  working_directory: ~/repo
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+    - run:
+        name: install dependencies
+        command: pip install --user tox
+    - run:
+        name: run tox
+        command: ~/.local/bin/tox
+    - save_cache:
+        paths:
+          - .tox
+          - ~/.cache/pip
+          - ~/.local
+          - ./eggs
+        key: cache-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
+
+jobs:
+  doctest:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: doctest
+  flake8:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: flake8
+  mypy:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: mypy
+  py35-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-core
+  py36-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-core
+  pypy3-core:
+    <<: *common
+    docker:
+      - image: pypy
+        environment:
+          TOXENV: pypy3-core
+  py35-backends:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-backends
+  py36-backends:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-backends
+workflows:
+  version: 2
+  test:
+    jobs:
+      - flake8
+      - mypy
+      - py35-core
+      - py36-core
+      - pypy3-core
+      - py35-backends
+      - py36-backends

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ tox==2.7.0
 flake8==3.0.4
 hypothesis==3.30.0
 bumpversion==0.5.3
+eth-hash[pycryptodome]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist=
-    py{35,36,py3}-{core,backends}
+    py{35,36}-{core,backends}
+    pypy3-core
     flake8
     mypy
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands=
     backends: py.test {posargs:tests/backends}
 deps =
     -r{toxinidir}/requirements-dev.txt
-    pycryptodome>=3.4.11,<4.0.0
     backends: coincurve>=7.0.0,<8.0.0
 setenv =
     backends: REQUIRE_COINCURVE=True


### PR DESCRIPTION
### What was wrong?

The testing configs were hard-coding the pycryptodome versioning. If/when eth-hash updates to work with a different pycryptodome major version, then this testing config would break.

### How was it fixed?

Use the eth-hash extra to define the pycryptodome version. Intentionally don't pin the eth-hash version, so that eth-utils specifies it.

#### Cute Animal Picture

![Cute animal picture](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRlLFRQjs7dwvJCvXHYoBR6CuCVG5RXd9Q2OsMy6VfzVexWK1mSOg)
