### PR TITLE
recover_msg() obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ new version explicitly, like `make release bump="--new-version 2.0.0-alpha.1 dev
 '0x1a642f0E3c3aF545E7AcBD38b07251B3990914F1'
 >>> signature.verify_msg(b'a message', pk.public_key)
 True
->>> signature.recover_msg(b'a message') == pk.public_key
+>>> signature.recover_public_key_from_msg(b'a message') == pk.public_key
 True
 ```
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands=flake8 {toxinidir}/eth_keys
 
 [testenv:mypy]
 basepython=python3.6
-deps=mypy
+deps=mypy<0.600
 setenv=MYPYPATH={toxinidir}
 # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
 commands=


### PR DESCRIPTION
Change recover_msg() is changed to recover_public_key_from_msg()

### What was wrong?



### How was it fixed?



#### Cute Animal Picture

![Cute animal picture]()
