### PR TITLE
modernize project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,24 +24,12 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  doctest:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: doctest
-  flake8:
+  lint:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: flake8
-  mypy:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: mypy
+          TOXENV: lint
   py35-core:
     <<: *common
     docker:
@@ -76,8 +64,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - flake8
-      - mypy
+      - lint
       - py35-core
       - py36-core
       - pypy3-core

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ release: clean
 	git config commit.gpgSign true
 	bumpversion $(bump)
 	git push && git push --tags
-	python setup.py sdist bdist_wheel upload
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pip install eth-keys
 ## Development
 
 ```sh
-pip install -e . -r requirements-dev.txt
+pip install -e .[dev]
 ```
 
 

--- a/eth_keys/validation.py
+++ b/eth_keys/validation.py
@@ -1,13 +1,11 @@
 from typing import Any
 
-from cytoolz import (
-    curry,
-)
 
 from eth_utils import (
     is_bytes,
     is_integer,
 )
+from eth_utils.toolz import curry
 
 from eth_keys.constants import (
     SECPK1_N,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-pytest==3.2.2
-tox==2.7.0
-flake8==3.0.4
-hypothesis==3.30.0
-bumpversion==0.5.3
-eth-hash[pycryptodome]

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,36 @@ from setuptools import (
 )
 
 
+deps = {
+    'eth-keys': [
+        "eth-utils>=1.3.0,<2.0.0",
+    ],
+    'test': [
+        'pytest==3.2.2',
+        'hypothesis==3.30.0',
+        "eth-hash[pysha3];implementation_name=='cpython'",
+        "eth-hash[pycryptodome];implementation_name=='pypy'",
+    ],
+    'lint': [
+        'flake8==3.0.4',
+        'mypy<0.600',
+    ],
+    'dev': [
+        'tox==2.7.0',
+        'bumpversion==0.5.3',
+        'twine',
+    ],
+}
+
+deps['dev'] = (
+    deps['dev'] +
+    deps['eth-keys'] +
+    deps['lint'] +
+    deps['test']
+)
+
+print(deps)
+
 setup(
     name='eth-keys',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
@@ -17,11 +47,9 @@ setup(
     url='https://github.com/ethereum/eth-keys',
     include_package_data=True,
     setup_requires=['setuptools-markdown'],
-    install_requires=[
-        "eth-utils>=1.0.0,<2.0.0",
-        "cytoolz>=0.9.0,<1.0.0",
-    ],
+    install_requires=deps['eth-keys'],
     py_modules=['eth_keys'],
+    extras_require=deps,
     license="MIT",
     zip_safe=False,
     package_data={'eth-keys': ['py.typed']},

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,7 @@
 envlist=
     py{35,36}-{core,backends}
     pypy3-core
-    flake8
-    mypy
+    lint
 
 [flake8]
 max-line-length= 100
@@ -14,8 +13,7 @@ usedevelop=True
 commands=
     core: py.test {posargs:tests/core}
     backends: py.test {posargs:tests/backends}
-deps =
-    -r{toxinidir}/requirements-dev.txt
+deps = .[test]
     backends: coincurve>=7.0.0,<8.0.0
 setenv =
     backends: REQUIRE_COINCURVE=True
@@ -24,15 +22,10 @@ basepython =
     py36: python3.6
     pypy3: pypy3
 
-[testenv:flake8]
-basepython=python
-deps=flake8
-commands=flake8 {toxinidir}/eth_keys
-
-[testenv:mypy]
+[testenv:lint]
 basepython=python3.6
-deps=mypy<0.600
-setenv=MYPYPATH={toxinidir}
-# TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
+deps=.[lint]
 commands=
+    flake8 {toxinidir}/eth_keys
+    # TODO: Drop --ignore-missing-imports once we have type annotations for eth_utils, coincurve and cytoolz
     mypy --follow-imports=silent --warn-unused-ignores --ignore-missing-imports --no-strict-optional --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs --disallow-any-generics -p eth_keys


### PR DESCRIPTION
### What does this do?

- combine `mypy` and `flake8` ci runs into as single `lint` run
- convert `requiretments-dev` to modern `.[dev]` based install pattern
- use `eth_utils.toolz` over direct `cytoolz` usage.

#### Cute Animal Picture

![breadcat](https://user-images.githubusercontent.com/824194/50359837-5633c500-051b-11e9-8224-ad33e1f10867.jpg)
