### PR TITLE
Fix deprecation warnings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "python.pythonPath": "venv/bin/python"
+}

--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -20,6 +20,9 @@ from eth_utils import (
     to_checksum_address,
     to_normalized_address,
 )
+from eth_utils.typing import (
+    ChecksumAddress,
+)
 
 from eth_keys.utils.address import (
     public_key_bytes_to_address,
@@ -208,7 +211,7 @@ class PublicKey(BaseKey, LazyBackend):
     #
     # Ethereum address conversions
     #
-    def to_checksum_address(self) -> bytes:
+    def to_checksum_address(self) -> ChecksumAddress:
         return to_checksum_address(public_key_bytes_to_address(self.to_bytes()))
 
     def to_address(self) -> str:

--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 if sys.version_info[0] == 2:
     ByteString = type(
         b'BaseString',
-        (collections.Sequence, basestring),  # noqa: F821
+        (collections.abc.Sequence, basestring),  # noqa: F821
         {},
     )  # type: Any
 else:
@@ -104,7 +104,7 @@ class LazyBackend:
         return get_backend(*args, **kwargs)
 
 
-class BaseKey(ByteString, collections.Hashable):
+class BaseKey(ByteString, collections.abc.Hashable):
     _raw_key = None  # type: bytes
 
     def to_hex(self) -> str:


### PR DESCRIPTION
### What was wrong?

The following deprecation warnings came up when using the library (e.g. when Trinity boots)

```
/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/eth_keys/datatypes.py:107: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
  class BaseKey(ByteString, collections.Hashable):
```


### How was it fixed?

Changed imports from `collections.*` to `collections.abc.*` 
Also fixes a wrong type hint that came up due to a newer `eth_utils` version.

#### Cute Animal Picture

![Cute animal picture](https://live.staticflickr.com/5503/9164889644_aab7baf955_b.jpg)
