### PR TITLE
Compressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,9 +189,18 @@ Each of these objects has all of the following APIs.
 
 The `PublicKey` class takes a single argument which must be a bytes string with length 64.
 
-> Note that some libraries prefix the byte serialized public key with a leading `\x04` byte which must be removed before use with the `PublicKey` object.
+> Note that there are two other common formats for public keys: 65 bytes with a leading `\x04` byte
+> and 33 bytes starting with either `\x02` or `\x03`. To use the former with the `PublicKey` object,
+> remove the first byte. For the latter, refer to `PublicKey.from_compressed_bytes`.
 
 The following methods are available:
+
+
+#### `PublicKey.from_compressed_bytes(compressed_bytes) -> PublicKey`
+
+This `classmethod` returns a new `PublicKey` instance computed from its compressed representation.
+
+* `compressed_bytes` **must** be a byte string of length 33 starting with `\x02` or `\x03`.
 
 
 #### `PublicKey.from_private(private_key) -> PublicKey`
@@ -227,6 +236,11 @@ for the given message.
 
 Same as `PublicKey.verify_msg` except that `message_hash` should be the Keccak
 hash of the `message`.
+
+
+#### `PublicKey.to_compressed_bytes() -> bytes`
+
+Returns the compressed representation of this public key.
 
 
 #### `PublicKey.to_address() -> text`

--- a/eth_keys/backends/base.py
+++ b/eth_keys/backends/base.py
@@ -27,3 +27,11 @@ class BaseECCBackend(object):
     def private_key_to_public_key(self,
                                   private_key: PrivateKey) -> PublicKey:
         raise NotImplementedError()
+
+    def decompress_public_key_bytes(self,
+                                    compressed_public_key_bytes: bytes) -> bytes:
+        raise NotImplementedError()
+
+    def compress_public_key_bytes(self,
+                                  uncompressed_public_key_bytes: bytes) -> bytes:
+        raise NotImplementedError()

--- a/eth_keys/backends/coincurve.py
+++ b/eth_keys/backends/coincurve.py
@@ -2,6 +2,10 @@ from __future__ import absolute_import
 
 from typing import Optional  # noqa: F401
 
+from eth_utils import (
+    big_endian_to_int,
+)
+
 from eth_keys.datatypes import (  # noqa: F401
     PrivateKey,
     PublicKey,
@@ -67,3 +71,17 @@ class CoinCurveECCBackend(BaseECCBackend):
             compressed=False,
         )[1:]
         return PublicKey(public_key_bytes, backend=self)
+
+    def decompress_public_key_bytes(self,
+                                    compressed_public_key_bytes: bytes) -> bytes:
+        public_key = self.keys.PublicKey(compressed_public_key_bytes)
+        return public_key.format(compressed=False)[1:]
+
+    def compress_public_key_bytes(self,
+                                  uncompressed_public_key_bytes: bytes) -> bytes:
+        point = (
+            big_endian_to_int(uncompressed_public_key_bytes[:32]),
+            big_endian_to_int(uncompressed_public_key_bytes[32:]),
+        )
+        public_key = self.keys.PublicKey.from_point(*point)
+        return public_key.format(compressed=True)

--- a/eth_keys/backends/coincurve.py
+++ b/eth_keys/backends/coincurve.py
@@ -14,6 +14,9 @@ from eth_keys.datatypes import (  # noqa: F401
 from eth_keys.exceptions import (
     BadSignature,
 )
+from eth_keys.validation import (
+    validate_uncompressed_public_key_bytes,
+)
 
 from .base import BaseECCBackend
 
@@ -79,6 +82,7 @@ class CoinCurveECCBackend(BaseECCBackend):
 
     def compress_public_key_bytes(self,
                                   uncompressed_public_key_bytes: bytes) -> bytes:
+        validate_uncompressed_public_key_bytes(uncompressed_public_key_bytes)
         point = (
             big_endian_to_int(uncompressed_public_key_bytes[:32]),
             big_endian_to_int(uncompressed_public_key_bytes[32:]),

--- a/eth_keys/backends/native/main.py
+++ b/eth_keys/backends/native/main.py
@@ -6,6 +6,8 @@ from .ecdsa import (
     ecdsa_raw_recover,
     ecdsa_raw_sign,
     private_key_to_public_key,
+    compress_public_key,
+    decompress_public_key,
 )
 
 from eth_keys.backends.base import BaseECCBackend
@@ -35,3 +37,11 @@ class NativeECCBackend(BaseECCBackend):
         public_key_bytes = private_key_to_public_key(private_key.to_bytes())
         public_key = PublicKey(public_key_bytes, backend=self)
         return public_key
+
+    def decompress_public_key_bytes(self,
+                                    compressed_public_key_bytes: bytes) -> bytes:
+        return decompress_public_key(compressed_public_key_bytes)
+
+    def compress_public_key_bytes(self,
+                                  uncompressed_public_key_bytes: bytes) -> bytes:
+        return compress_public_key(uncompressed_public_key_bytes)

--- a/eth_keys/main.py
+++ b/eth_keys/main.py
@@ -89,16 +89,6 @@ class KeyAPI(LazyBackend):
             )
         return public_key
 
-    def decompress_public_key_bytes(self,
-                                    compressed_public_key_bytes: bytes) -> bytes:
-        validate_compressed_public_key_bytes(compressed_public_key_bytes)
-        return self.backend.decompress_public_key_bytes(compressed_public_key_bytes)
-
-    def compress_public_key_bytes(self,
-                                  uncompressed_public_key_bytes: bytes) -> bytes:
-        validate_uncompressed_public_key_bytes(uncompressed_public_key_bytes)
-        return self.backend.compress_public_key_bytes(uncompressed_public_key_bytes)
-
 
 # This creates an easy to import backend which will lazily fetch whatever
 # backend has been configured at runtime (as opposed to import or instantiation time).

--- a/eth_keys/main.py
+++ b/eth_keys/main.py
@@ -11,6 +11,8 @@ from eth_keys.exceptions import (
 )
 from eth_keys.validation import (
     validate_message_hash,
+    validate_compressed_public_key_bytes,
+    validate_uncompressed_public_key_bytes,
 )
 
 
@@ -86,6 +88,16 @@ class KeyAPI(LazyBackend):
                 "an instance of `eth_keys.datatypes.PublicKey`"
             )
         return public_key
+
+    def decompress_public_key_bytes(self,
+                                    compressed_public_key_bytes: bytes) -> bytes:
+        validate_compressed_public_key_bytes(compressed_public_key_bytes)
+        return self.backend.decompress_public_key_bytes(compressed_public_key_bytes)
+
+    def compress_public_key_bytes(self,
+                                  uncompressed_public_key_bytes: bytes) -> bytes:
+        validate_uncompressed_public_key_bytes(uncompressed_public_key_bytes)
+        return self.backend.compress_public_key_bytes(uncompressed_public_key_bytes)
 
 
 # This creates an easy to import backend which will lazily fetch whatever

--- a/eth_keys/validation.py
+++ b/eth_keys/validation.py
@@ -1,7 +1,7 @@
 from typing import Any
 
-
 from eth_utils import (
+    encode_hex,
     is_bytes,
     is_integer,
 )
@@ -50,35 +50,47 @@ def validate_lte(value: Any, maximum: int) -> None:
 validate_lt_secpk1n = validate_lte(maximum=SECPK1_N - 1)
 
 
+def validate_bytes_length(value: bytes, expected_length: int, name: str) -> None:
+    actual_length = len(value)
+    if actual_length != expected_length:
+        raise ValidationError(
+            "Unexpected {name} length: Expected {expected_length}, but got {actual_length} "
+            "bytes".format(
+                name=name,
+                expected_length=expected_length,
+                actual_length=actual_length,
+            )
+        )
+
+
 def validate_message_hash(value: Any) -> None:
     validate_bytes(value)
-    if len(value) != 32:
-        raise ValidationError("Unexpected signature format.  Must be length 65 byte string")
+    validate_bytes_length(value, 32, "message hash")
 
 
 def validate_uncompressed_public_key_bytes(value: Any) -> None:
     validate_bytes(value)
-    if len(value) != 64:
-        raise ValidationError(
-            "Unexpected uncompressed public key format.  Must be length 64 byte string"
-        )
+    validate_bytes_length(value, 64, "uncompressed public key")
 
 
 def validate_compressed_public_key_bytes(value: Any) -> None:
     validate_bytes(value)
-    if len(value) != 33:
+    validate_bytes_length(value, 33, "compressed public key")
+    first_byte = value[0:1]
+    if first_byte not in (b"\x02", b"\x03"):
         raise ValidationError(
-            "Unexpected compressed public key format.  Must be length 33 byte string"
+            "Unexpected compressed public key format: Must start with 0x02 or 0x03, but starts "
+            "with {first_byte}".format(
+                first_byte=encode_hex(first_byte),
+            )
         )
 
 
 def validate_private_key_bytes(value: Any) -> None:
     validate_bytes(value)
-    if len(value) != 32:
-        raise ValidationError("Unexpected private key format.  Must be length 32 byte string")
+    validate_bytes_length(value, 32, "private key")
 
 
 def validate_signature_bytes(value: Any) -> None:
     validate_bytes(value)
-    if len(value) != 65:
-        raise ValidationError("Unexpected signature format.  Must be length 65 byte string")
+    validate_bytes_length(value, 65, "signature")

--- a/eth_keys/validation.py
+++ b/eth_keys/validation.py
@@ -56,10 +56,20 @@ def validate_message_hash(value: Any) -> None:
         raise ValidationError("Unexpected signature format.  Must be length 65 byte string")
 
 
-def validate_public_key_bytes(value: Any) -> None:
+def validate_uncompressed_public_key_bytes(value: Any) -> None:
     validate_bytes(value)
     if len(value) != 64:
-        raise ValidationError("Unexpected public key format.  Must be length 64 byte string")
+        raise ValidationError(
+            "Unexpected uncompressed public key format.  Must be length 64 byte string"
+        )
+
+
+def validate_compressed_public_key_bytes(value: Any) -> None:
+    validate_bytes(value)
+    if len(value) != 33:
+        raise ValidationError(
+            "Unexpected compressed public key format.  Must be length 33 byte string"
+        )
 
 
 def validate_private_key_bytes(value: Any) -> None:

--- a/tests/backends/conftest.py
+++ b/tests/backends/conftest.py
@@ -30,12 +30,14 @@ for secret in ['alice', 'bob', 'eve']:
     print("    raw_sig='{}')".format(crypto._decode_sig(sig)))
     assert crypto.ecdsa_recover(msghash, sig) == pubkey
 """
+# Compressed public keys have been calculated with coincurve
 
 
 SECRETS = {
     "alice": dict(
         privkey=decode_hex('0x9c0257114eb9399a2985f8e75dad7600c5d89fe3824ffa99ec1c3eb8bf3b0501'),
         pubkey=decode_hex('0x5eed5fa3a67696c334762bb4823e585e2ee579aba3558d9955296d6c04541b426078dbd48d74af1fd0c72aa1a05147cf17be6b60bdbed6ba19b08ec28445b0ca'),  # noqa: E501
+        compressed_pubkey=decode_hex('0x025eed5fa3a67696c334762bb4823e585e2ee579aba3558d9955296d6c04541b42'),  # noqa: E501
         sig=decode_hex('0xb20e2ea5d3cbaa83c1e0372f110cf12535648613b479b64c1a8c1a20c5021f380434d07ec5795e3f789794351658e80b7faf47a46328f41e019d7b853745cdfd01'),  # noqa: E501
         raw_sig=(
             1,
@@ -46,6 +48,7 @@ SECRETS = {
     "bob": dict(
         privkey=decode_hex('0x38e47a7b719dce63662aeaf43440326f551b8a7ee198cee35cb5d517f2d296a2'),
         pubkey=decode_hex('0x347746ccb908e583927285fa4bd202f08e2f82f09c920233d89c47c79e48f937d049130e3d1c14cf7b21afefc057f71da73dec8e8ff74ff47dc6a574ccd5d570'),  # noqa: E501
+        compressed_pubkey=decode_hex('0x02347746ccb908e583927285fa4bd202f08e2f82f09c920233d89c47c79e48f937'),  # noqa: E501
         sig=decode_hex('0x5c48ea4f0f2257fa23bd25e6fcb0b75bbe2ff9bbda0167118dab2bb6e31ba76e691dbdaf2a231fc9958cd8edd99507121f8184042e075cf10f98ba88abff1f3601'),  # noqa: E501
         raw_sig=(
             1,
@@ -56,6 +59,7 @@ SECRETS = {
     "eve": dict(
         privkey=decode_hex('0x876be0999ed9b7fc26f1b270903ef7b0c35291f89407903270fea611c85f515c'),
         pubkey=decode_hex('0xc06641f0d04f64dba13eac9e52999f2d10a1ff0ca68975716b6583dee0318d91e7c2aed363ed22edeba2215b03f6237184833fd7d4ad65f75c2c1d5ea0abecc0'),  # noqa: E501
+        compressed_pubkey=decode_hex('0x02c06641f0d04f64dba13eac9e52999f2d10a1ff0ca68975716b6583dee0318d91'),  # noqa: E501
         sig=decode_hex('0xbabeefc5082d3ca2e0bc80532ab38f9cfb196fb9977401b2f6a98061f15ed603603d0af084bf906b2cdf6cdde8b2e1c3e51a41af5e9adec7f3643b3f1aa2aadf00'),  # noqa: E501
         raw_sig=(
             0,

--- a/tests/backends/strategies.py
+++ b/tests/backends/strategies.py
@@ -1,0 +1,23 @@
+from hypothesis import (
+    strategies as st,
+)
+
+from eth_utils import (
+    int_to_big_endian,
+)
+
+from eth_keys.constants import (
+    SECPK1_N,
+)
+from eth_keys.utils.padding import (
+    pad32,
+)
+
+
+private_key_st = st.integers(min_value=1, max_value=SECPK1_N).map(
+    int_to_big_endian,
+).map(pad32)
+
+
+message_hash_st = st.binary(min_size=32, max_size=32)
+signature_st = st.binary(min_size=65, max_size=65)

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -69,14 +69,16 @@ def test_decompress_public_key_bytes(key_api, key_fixture):
     compressed = key_fixture['compressed_pubkey']
     uncompressed = key_fixture['pubkey']
 
-    assert key_api.decompress_public_key_bytes(compressed) == uncompressed
+    key_from_compressed = key_api.PublicKey.from_compressed_bytes(compressed)
+    assert key_from_compressed.to_bytes() == uncompressed
 
 
 def test_compress_public_key_bytes(key_api, key_fixture):
     uncompressed = key_fixture['pubkey']
     compressed = key_fixture['compressed_pubkey']
 
-    assert key_api.compress_public_key_bytes(uncompressed) == compressed
+    key_from_uncompressed = key_api.PublicKey(uncompressed)
+    assert key_from_uncompressed.to_compressed_bytes() == compressed
 
 
 @given(
@@ -84,12 +86,8 @@ def test_compress_public_key_bytes(key_api, key_fixture):
 )
 def test_compress_decompress_inversion(key_api, private_key_bytes):
     private_key = key_api.PrivateKey(private_key_bytes)
-    public_key = private_key.public_key
-    uncompressed = public_key.to_bytes()
-    compressed = public_key.to_compressed_bytes()
 
-    compress = key_api.compress_public_key_bytes
-    decompress = key_api.decompress_public_key_bytes
-
-    assert decompress(compress(uncompressed)) == uncompressed
-    assert compress(decompress(compressed)) == compressed
+    original = private_key.public_key
+    compressed_bytes = original.to_compressed_bytes()
+    decompressed = key_api.PublicKey.from_compressed_bytes(compressed_bytes)
+    assert decompressed == original

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -55,3 +55,17 @@ def test_ecdsa_recover(key_api, key_fixture):
     public_key = key_api.PublicKey(key_fixture['pubkey'])
 
     assert key_api.ecdsa_recover(MSGHASH, signature) == public_key
+
+
+def test_decompress_public_key_bytes(key_api, key_fixture):
+    compressed = key_fixture['compressed_pubkey']
+    uncompressed = key_fixture['pubkey']
+
+    assert key_api.decompress_public_key_bytes(compressed) == uncompressed
+
+
+def compress_public_key_bytes(key_api, key_fixture):
+    uncompressed = key_fixture['pubkey']
+    compressed = key_fixture['compressed_pubkey']
+
+    assert key_api.compress_public_key_bytes(uncompressed) == compressed

--- a/tests/backends/test_native_backend_against_coincurve.py
+++ b/tests/backends/test_native_backend_against_coincurve.py
@@ -151,31 +151,17 @@ def test_coincurve_to_native_invalid_signatures(message_hash,
 
 @given(
     private_key_bytes=private_key_st,
-    direction=st.one_of(
-        st.just('coincurve-to-native'),
-        st.just('native-to-coincurve'),
-    ),
 )
 def test_public_key_compression_is_equal(private_key_bytes,
-                                         direction,
                                          native_key_api,
                                          coincurve_key_api):
-    if direction == 'coincurve-to-native':
-        backend_a = coincurve_key_api
-        backend_b = native_key_api
-    elif direction == 'native-to-coincurve':
-        backend_b = coincurve_key_api
-        backend_a = native_key_api
-    else:
-        assert False, "invariant"
+    native_public_key = native_key_api.PrivateKey(private_key_bytes).public_key
+    coincurve_public_key = coincurve_key_api.PrivateKey(private_key_bytes).public_key
 
-    public_key_a = backend_a.PrivateKey(private_key_bytes).public_key
-    public_key_b = backend_b.PrivateKey(private_key_bytes).public_key
+    native_compressed_public_key = native_public_key.to_compressed_bytes()
+    coincurve_compressed_public_key = coincurve_public_key.to_compressed_bytes()
 
-    compressed_public_key_a = public_key_a.to_compressed_bytes()
-    compressed_public_key_b = public_key_b.to_compressed_bytes()
-
-    assert compressed_public_key_a == compressed_public_key_b
+    assert native_compressed_public_key == coincurve_compressed_public_key
 
 
 @given(

--- a/tests/backends/test_native_backend_against_coincurve.py
+++ b/tests/backends/test_native_backend_against_coincurve.py
@@ -7,32 +7,22 @@ from hypothesis import (
 )
 
 from eth_utils import (
-    int_to_big_endian,
     keccak,
 )
 
 from eth_keys.exceptions import (
     BadSignature,
 )
-from eth_keys.utils.padding import (
-    pad32,
-)
 
 from eth_keys import KeyAPI
 from eth_keys.backends import CoinCurveECCBackend
 from eth_keys.backends import NativeECCBackend
-from eth_keys.constants import (
-    SECPK1_N,
+
+from strategies import (
+    private_key_st,
+    message_hash_st,
+    signature_st,
 )
-
-
-private_key_st = st.integers(min_value=1, max_value=SECPK1_N).map(
-    int_to_big_endian,
-).map(pad32)
-
-
-message_hash_st = st.binary(min_size=32, max_size=32)
-signature_st = st.binary(min_size=65, max_size=65)
 
 
 MSG = b'message'

--- a/tests/backends/test_native_backend_against_coincurve.py
+++ b/tests/backends/test_native_backend_against_coincurve.py
@@ -157,3 +157,62 @@ def test_coincurve_to_native_invalid_signatures(message_hash,
     public_key_b = backend_b.ecdsa_recover(message_hash, signature_a)
 
     assert public_key_b == public_key_a
+
+
+@given(
+    private_key_bytes=private_key_st,
+    direction=st.one_of(
+        st.just('coincurve-to-native'),
+        st.just('native-to-coincurve'),
+    ),
+)
+def test_public_key_compression_is_equal(private_key_bytes,
+                                         direction,
+                                         native_key_api,
+                                         coincurve_key_api):
+    if direction == 'coincurve-to-native':
+        backend_a = coincurve_key_api
+        backend_b = native_key_api
+    elif direction == 'native-to-coincurve':
+        backend_b = coincurve_key_api
+        backend_a = native_key_api
+    else:
+        assert False, "invariant"
+
+    public_key_a = backend_a.PrivateKey(private_key_bytes).public_key
+    public_key_b = backend_b.PrivateKey(private_key_bytes).public_key
+
+    compressed_public_key_a = public_key_a.to_compressed_bytes()
+    compressed_public_key_b = public_key_b.to_compressed_bytes()
+
+    assert compressed_public_key_a == compressed_public_key_b
+
+
+@given(
+    private_key_bytes=private_key_st,
+    direction=st.one_of(
+        st.just('coincurve-to-native'),
+        st.just('native-to-coincurve'),
+    ),
+)
+def test_public_key_decompression_is_equal(private_key_bytes,
+                                           direction,
+                                           native_key_api,
+                                           coincurve_key_api):
+
+    if direction == 'coincurve-to-native':
+        backend_a = coincurve_key_api
+        backend_b = native_key_api
+    elif direction == 'native-to-coincurve':
+        backend_b = coincurve_key_api
+        backend_a = native_key_api
+    else:
+        assert False, "invariant"
+
+    public_key_template = backend_a.PrivateKey(private_key_bytes).public_key
+    compressed_public_key = public_key_template.to_compressed_bytes()
+
+    public_key_a = backend_a.PublicKey.from_compressed_bytes(compressed_public_key)
+    public_key_b = backend_b.PublicKey.from_compressed_bytes(compressed_public_key)
+
+    assert public_key_a == public_key_b

--- a/tests/core/test_key_and_signature_datastructures.py
+++ b/tests/core/test_key_and_signature_datastructures.py
@@ -123,3 +123,10 @@ def test_bytes_conversion(key_api, private_key):
     assert public_key.to_bytes() == public_key._raw_key
     assert private_key.to_bytes() == private_key._raw_key
     assert signature.to_bytes() == key_api.Signature(signature.to_bytes()).to_bytes()
+
+
+def test_compressed_bytes_conversion(key_api, private_key):
+    public_key = private_key.public_key
+    compressed_bytes = public_key.to_compressed_bytes()
+    assert len(compressed_bytes) == 33
+    assert key_api.PublicKey.from_compressed_bytes(compressed_bytes) == public_key

--- a/tests/core/test_key_and_signature_datastructures.py
+++ b/tests/core/test_key_and_signature_datastructures.py
@@ -14,6 +14,9 @@ from eth_utils import (
 
 from eth_keys import KeyAPI
 from eth_keys.backends import NativeECCBackend
+from eth_keys.exceptions import (
+    ValidationError,
+)
 
 
 MSG = b'message'
@@ -130,3 +133,14 @@ def test_compressed_bytes_conversion(key_api, private_key):
     compressed_bytes = public_key.to_compressed_bytes()
     assert len(compressed_bytes) == 33
     assert key_api.PublicKey.from_compressed_bytes(compressed_bytes) == public_key
+
+
+def test_compressed_bytes_validation(key_api, private_key):
+    valid_key = private_key.public_key.to_compressed_bytes()
+
+    with pytest.raises(ValidationError):
+        key_api.PublicKey.from_compressed_bytes(valid_key + b"\x00")
+    with pytest.raises(ValidationError):
+        key_api.PublicKey.from_compressed_bytes(valid_key[:-1])
+    with pytest.raises(ValidationError):
+        key_api.PublicKey.from_compressed_bytes(b"\x04" + valid_key[1:])

--- a/tests/core/test_key_api_proxy_methods.py
+++ b/tests/core/test_key_api_proxy_methods.py
@@ -67,3 +67,15 @@ def test_key_api_ecdsa_recover_validation(key_api, signature, public_key):
         key_api.ecdsa_recover(MSG, signature)
 
     assert key_api.ecdsa_recover(MSGHASH, signature) == public_key
+
+def test_key_api_decompress_public_key_validation(key_api, public_key):
+    compressed_bytes = public_key.to_compressed_bytes()
+    uncompressed_bytes = public_key.to_bytes()
+
+    with pytest.raises(ValidationError):
+        key_api.decompress_public_key_bytes(uncompressed_bytes)
+    with pytest.raises(ValidationError):
+        key_api.compress_public_key_bytes(compressed_bytes)
+
+    assert key_api.decompress_public_key_bytes(compressed_bytes) == uncompressed_bytes
+    assert key_api.compress_public_key_bytes(uncompressed_bytes) == compressed_bytes

--- a/tests/core/test_key_api_proxy_methods.py
+++ b/tests/core/test_key_api_proxy_methods.py
@@ -67,15 +67,3 @@ def test_key_api_ecdsa_recover_validation(key_api, signature, public_key):
         key_api.ecdsa_recover(MSG, signature)
 
     assert key_api.ecdsa_recover(MSGHASH, signature) == public_key
-
-def test_key_api_decompress_public_key_validation(key_api, public_key):
-    compressed_bytes = public_key.to_compressed_bytes()
-    uncompressed_bytes = public_key.to_bytes()
-
-    with pytest.raises(ValidationError):
-        key_api.decompress_public_key_bytes(uncompressed_bytes)
-    with pytest.raises(ValidationError):
-        key_api.compress_public_key_bytes(compressed_bytes)
-
-    assert key_api.decompress_public_key_bytes(compressed_bytes) == uncompressed_bytes
-    assert key_api.compress_public_key_bytes(uncompressed_bytes) == compressed_bytes


### PR DESCRIPTION
### What was wrong?

Missing support for compressed public keys (#55).

### How was it fixed?

- Add `to/from_compressed_bytes` methods to `PublicKey` class.
- Add implementations for the coincurve and native backend.
- Add some tests.

I'm not an expert in cryptography, so please review carefully, especially the native backend code.

#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/29854669/57235207-aa4eca00-7022-11e9-902f-2da640e6f689.jpg)