### PR TITLE
Non-Recoverable Signatures

### DIFF
--- a/eth_keys/backends/base.py
+++ b/eth_keys/backends/base.py
@@ -1,6 +1,8 @@
 from typing import Any  # noqa: F401
 
 from eth_keys.datatypes import (
+    BaseSignature,
+    NonRecoverableSignature,
     PrivateKey,
     PublicKey,
     Signature,
@@ -13,11 +15,16 @@ class BaseECCBackend(object):
                    private_key: PrivateKey) -> Signature:
         raise NotImplementedError()
 
+    def ecdsa_sign_non_recoverable(self,
+                                   msg_hash: bytes,
+                                   private_key: PrivateKey) -> NonRecoverableSignature:
+        raise NotImplementedError()
+
     def ecdsa_verify(self,
                      msg_hash: bytes,
-                     signature: Signature,
+                     signature: BaseSignature,
                      public_key: PublicKey) -> bool:
-        return self.ecdsa_recover(msg_hash, signature) == public_key
+        raise NotImplementedError()
 
     def ecdsa_recover(self,
                       msg_hash: bytes,

--- a/eth_keys/backends/native/ecdsa.py
+++ b/eth_keys/backends/native/ecdsa.py
@@ -120,14 +120,11 @@ def ecdsa_raw_sign(msg_hash: bytes,
 
 
 def ecdsa_raw_verify(msg_hash: bytes,
-                     vrs: Tuple[int, int, int],
+                     rs: Tuple[int, int],
                      public_key_bytes: bytes) -> bool:
     raw_public_key = decode_public_key(public_key_bytes)
 
-    v, r, s = vrs
-    v += 27
-    if not (27 <= v <= 34):
-        raise BadSignature("Invalid Signature")
+    r, s = rs
 
     w = inv(s, N)
     z = big_endian_to_int(msg_hash)

--- a/eth_keys/backends/native/main.py
+++ b/eth_keys/backends/native/main.py
@@ -32,9 +32,8 @@ class NativeECCBackend(BaseECCBackend):
     def ecdsa_sign_non_recoverable(self,
                                    msg_hash: bytes,
                                    private_key: PrivateKey) -> NonRecoverableSignature:
-        signature_vrs = ecdsa_raw_sign(msg_hash, private_key.to_bytes())
-        signature_rs = signature_vrs[1:]
-        signature = NonRecoverableSignature(rs=signature_rs, backend=self)
+        _, signature_r, signature_s = ecdsa_raw_sign(msg_hash, private_key.to_bytes())
+        signature = NonRecoverableSignature(rs=(signature_r, signature_s), backend=self)
         return signature
 
     def ecdsa_verify(self,

--- a/eth_keys/backends/native/main.py
+++ b/eth_keys/backends/native/main.py
@@ -5,6 +5,7 @@ from typing import Optional  # noqa: F401
 from .ecdsa import (
     ecdsa_raw_recover,
     ecdsa_raw_sign,
+    ecdsa_raw_verify,
     private_key_to_public_key,
     compress_public_key,
     decompress_public_key,
@@ -12,6 +13,8 @@ from .ecdsa import (
 
 from eth_keys.backends.base import BaseECCBackend
 from eth_keys.datatypes import (  # noqa: F401
+    BaseSignature,
+    NonRecoverableSignature,
     PrivateKey,
     PublicKey,
     Signature,
@@ -25,6 +28,20 @@ class NativeECCBackend(BaseECCBackend):
         signature_vrs = ecdsa_raw_sign(msg_hash, private_key.to_bytes())
         signature = Signature(vrs=signature_vrs, backend=self)
         return signature
+
+    def ecdsa_sign_non_recoverable(self,
+                                   msg_hash: bytes,
+                                   private_key: PrivateKey) -> NonRecoverableSignature:
+        signature_vrs = ecdsa_raw_sign(msg_hash, private_key.to_bytes())
+        signature_rs = signature_vrs[1:]
+        signature = NonRecoverableSignature(rs=signature_rs, backend=self)
+        return signature
+
+    def ecdsa_verify(self,
+                     msg_hash: bytes,
+                     signature: BaseSignature,
+                     public_key: PublicKey) -> bool:
+        return ecdsa_raw_verify(msg_hash, signature.rs, public_key.to_bytes())
 
     def ecdsa_recover(self,
                       msg_hash: bytes,

--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -44,15 +44,13 @@ from eth_keys.exceptions import (
     ValidationError,
 )
 from eth_keys.validation import (
-    validate_gte,
-    validate_integer,
-    validate_lt_secpk1n,
-    validate_lte,
     validate_private_key_bytes,
     validate_compressed_public_key_bytes,
     validate_uncompressed_public_key_bytes,
     validate_recoverable_signature_bytes,
     validate_non_recoverable_signature_bytes,
+    validate_signature_v,
+    validate_signature_r_or_s,
 )
 
 if TYPE_CHECKING:
@@ -283,15 +281,12 @@ class BaseSignature(ByteString, LazyBackend, ABC):
                  ) -> None:
         for value in rs:
             try:
-                validate_integer(value)
-                validate_gte(value, 0)
-                validate_lt_secpk1n(value)
+                validate_signature_r_or_s(value)
             except ValidationError as error:
                 raise BadSignature(error) from error
 
         self._r, self._s = rs
         super().__init__(backend=backend)
-
 
     @property
     def r(self) -> int:
@@ -396,26 +391,17 @@ class Signature(BaseSignature):
 
     @v.setter
     def v(self, value: int) -> None:
-        validate_integer(value)
-        validate_gte(value, minimum=0)
-        validate_lte(value, maximum=1)
-
+        validate_signature_v(value)
         self._v = value
 
     @BaseSignature.r.setter
     def r(self, value: int) -> None:
-        validate_integer(value)
-        validate_gte(value, 0)
-        validate_lt_secpk1n(value)
-
+        validate_signature_r_or_s(value)
         self._r = value
 
     @BaseSignature.s.setter
     def s(self, value: int) -> None:
-        validate_integer(value)
-        validate_gte(value, 0)
-        validate_lt_secpk1n(value)
-
+        validate_signature_r_or_s(value)
         self._s = value
 
     @property

--- a/eth_keys/main.py
+++ b/eth_keys/main.py
@@ -1,7 +1,9 @@
 from typing import (Any, Union, Type)  # noqa: F401
 
 from eth_keys.datatypes import (
+    BaseSignature,
     LazyBackend,
+    NonRecoverableSignature,
     PublicKey,
     PrivateKey,
     Signature,
@@ -21,6 +23,7 @@ from eth_keys.validation import (
 _PublicKey = PublicKey
 _PrivateKey = PrivateKey
 _Signature = Signature
+_NonRecoverableSignature = NonRecoverableSignature
 
 
 class KeyAPI(LazyBackend):
@@ -30,6 +33,7 @@ class KeyAPI(LazyBackend):
     PublicKey = PublicKey  # type: Type[_PublicKey]
     PrivateKey = PrivateKey  # type: Type[_PrivateKey]
     Signature = Signature  # type: Type[_Signature]
+    NonRecoverableSignature = NonRecoverableSignature  # type: Type[_NonRecoverableSignature]
 
     #
     # Proxy method calls to the backends
@@ -50,15 +54,36 @@ class KeyAPI(LazyBackend):
             )
         return signature
 
+    def ecdsa_sign_non_recoverable(self,
+                                   message_hash: bytes,
+                                   private_key: _PrivateKey) -> _NonRecoverableSignature:
+        validate_message_hash(message_hash)
+        if not isinstance(private_key, PrivateKey):
+            raise ValidationError(
+                "The `private_key` must be an instance of `eth_keys.datatypes.PrivateKey`"
+            )
+        signature = self.backend.ecdsa_sign_non_recoverable(message_hash, private_key)
+        if not isinstance(signature, NonRecoverableSignature):
+            raise ValidationError(
+                "Backend returned an invalid signature.  Return value must be "
+                "an instance of `eth_keys.datatypes.Signature`"
+            )
+        return signature
+
     def ecdsa_verify(self,
                      message_hash: bytes,
-                     signature: _Signature,
+                     signature: BaseSignature,
                      public_key: _PublicKey) -> bool:
+        validate_message_hash(message_hash)
         if not isinstance(public_key, PublicKey):
             raise ValidationError(
                 "The `public_key` must be an instance of `eth_keys.datatypes.PublicKey`"
             )
-        return self.ecdsa_recover(message_hash, signature) == public_key
+        if not isinstance(signature, BaseSignature):
+            raise ValidationError(
+                "The `signature` must be an instance of `eth_keys.datatypes.BaseSignature`"
+            )
+        return self.backend.ecdsa_verify(message_hash, signature, public_key)
 
     def ecdsa_recover(self,
                       message_hash: bytes,

--- a/eth_keys/validation.py
+++ b/eth_keys/validation.py
@@ -91,6 +91,11 @@ def validate_private_key_bytes(value: Any) -> None:
     validate_bytes_length(value, 32, "private key")
 
 
-def validate_signature_bytes(value: Any) -> None:
+def validate_recoverable_signature_bytes(value: Any) -> None:
     validate_bytes(value)
-    validate_bytes_length(value, 65, "signature")
+    validate_bytes_length(value, 65, "recoverable signature")
+
+
+def validate_non_recoverable_signature_bytes(value: Any) -> None:
+    validate_bytes(value)
+    validate_bytes_length(value, 64, "non recoverable signature")

--- a/eth_keys/validation.py
+++ b/eth_keys/validation.py
@@ -99,3 +99,15 @@ def validate_recoverable_signature_bytes(value: Any) -> None:
 def validate_non_recoverable_signature_bytes(value: Any) -> None:
     validate_bytes(value)
     validate_bytes_length(value, 64, "non recoverable signature")
+
+
+def validate_signature_v(value: int) -> None:
+    validate_integer(value)
+    validate_gte(value, minimum=0)
+    validate_lte(value, maximum=1)
+
+
+def validate_signature_r_or_s(value: int) -> None:
+    validate_integer(value)
+    validate_gte(value, 0)
+    validate_lt_secpk1n(value)

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -51,6 +51,13 @@ def test_ecdsa_sign(key_api, key_fixture):
     assert key_api.ecdsa_verify(MSGHASH, signature, private_key.public_key)
 
 
+def test_ecdsa_sign_non_recoverable(key_api, key_fixture):
+    private_key = key_api.PrivateKey(key_fixture['privkey'])
+    signature = key_api.ecdsa_sign_non_recoverable(MSGHASH, private_key)
+
+    assert key_api.ecdsa_verify(MSGHASH, signature, private_key.public_key)
+
+
 def test_ecdsa_verify(key_api, key_fixture):
     signature = key_api.Signature(vrs=key_fixture['raw_sig'])
     public_key = key_api.PublicKey(key_fixture['pubkey'])

--- a/tests/core/test_key_and_signature_datastructures.py
+++ b/tests/core/test_key_and_signature_datastructures.py
@@ -72,11 +72,14 @@ def test_recover_from_public_key_class(key_api, private_key):
 
 
 def test_verify_from_public_key_obj(key_api, private_key):
-    signature = key_api.ecdsa_sign_non_recoverable(MSGHASH, private_key)
+    non_recoverable_signature = key_api.ecdsa_sign_non_recoverable(MSGHASH, private_key)
+    recoverable_signature = key_api.ecdsa_sign_non_recoverable(MSGHASH, private_key)
+
     public_key = private_key.public_key
 
-    assert public_key.verify_msg_hash(MSGHASH, signature)
-    assert public_key.verify_msg(MSG, signature)
+    for signature in (recoverable_signature, non_recoverable_signature):
+        assert public_key.verify_msg_hash(MSGHASH, signature)
+        assert public_key.verify_msg(MSG, signature)
 
 
 def test_from_private_for_public_key_class(key_api, private_key):

--- a/tests/core/test_key_and_signature_datastructures.py
+++ b/tests/core/test_key_and_signature_datastructures.py
@@ -45,8 +45,20 @@ def test_signing_from_private_key_obj(key_api, private_key):
     assert key_api.ecdsa_verify(MSGHASH, signature, private_key.public_key)
 
 
+def test_signing_non_recoverable_from_private_key_obj(key_api, private_key):
+    signature = private_key.sign_msg_non_recoverable(MSG)
+
+    assert key_api.ecdsa_verify(MSGHASH, signature, private_key.public_key)
+
+
 def test_hash_signing_from_private_key_obj(key_api, private_key):
     signature = private_key.sign_msg_hash(MSGHASH)
+
+    assert key_api.ecdsa_verify(MSGHASH, signature, private_key.public_key)
+
+
+def test_hash_signing_non_recoverable_from_private_key_obj(key_api, private_key):
+    signature = private_key.sign_msg_hash_non_recoverable(MSGHASH)
 
     assert key_api.ecdsa_verify(MSGHASH, signature, private_key.public_key)
 
@@ -60,7 +72,7 @@ def test_recover_from_public_key_class(key_api, private_key):
 
 
 def test_verify_from_public_key_obj(key_api, private_key):
-    signature = key_api.ecdsa_sign(MSGHASH, private_key)
+    signature = key_api.ecdsa_sign_non_recoverable(MSGHASH, private_key)
     public_key = private_key.public_key
 
     assert public_key.verify_msg_hash(MSGHASH, signature)
@@ -75,6 +87,13 @@ def test_from_private_for_public_key_class(key_api, private_key):
 
 def test_verify_from_signature_obj(key_api, private_key):
     signature = key_api.ecdsa_sign(MSGHASH, private_key)
+
+    assert signature.verify_msg_hash(MSGHASH, private_key.public_key)
+    assert signature.verify_msg(MSG, private_key.public_key)
+
+
+def test_verify_from_non_recoverable_signature_obj(key_api, private_key):
+    signature = key_api.ecdsa_sign(MSGHASH, private_key).to_non_recoverable_signature()
 
     assert signature.verify_msg_hash(MSGHASH, private_key.public_key)
     assert signature.verify_msg(MSG, private_key.public_key)

--- a/tests/core/test_key_api_proxy_methods.py
+++ b/tests/core/test_key_api_proxy_methods.py
@@ -49,6 +49,16 @@ def test_key_api_ecdsa_sign_validation(key_api, private_key):
     assert signature.verify_msg_hash(MSGHASH, private_key.public_key)
 
 
+def test_key_api_ecdsa_sign_non_recoverable_validation(key_api, private_key):
+    with pytest.raises(ValidationError):
+        key_api.ecdsa_sign_non_recoverable(MSGHASH, private_key.to_bytes())
+    with pytest.raises(ValidationError):
+        key_api.ecdsa_sign_non_recoverable(MSG, private_key)
+
+    signature = key_api.ecdsa_sign_non_recoverable(MSGHASH, private_key)
+    assert signature.verify_msg_hash(MSGHASH, private_key.public_key)
+
+
 def test_key_api_ecdsa_verify_validation(key_api, signature, public_key):
     with pytest.raises(ValidationError):
         key_api.ecdsa_verify(MSGHASH, signature.to_bytes(), public_key)


### PR DESCRIPTION
### What was wrong?

#57 

### How was it fixed?

Signatures without `v` values are implemented in a new class called `NonRecoverableSignature`. Some of the shared functionality with the existing `Signature` class has been moved to `BaseSignature`. Creating non recoverable signatures is handled by new backend methods. Verifying them uses the existing ones, which have been updated to accept all `BaseSignatures` (i.e. not recover and compare, but direct verification).

Coincurve uses a DER format to encode/decode these signatures. As it is quite complicated I added a new dependency: [asn1tools](https://github.com/eerimoq/asn1tools) which looks relatively well maintained.

This should probably be merged after #56, then I can use the improved validation functions from there.

#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/29854669/57473846-16366a00-7291-11e9-9c65-6549c00d5fe7.jpg)