### PR TITLE
Piper/fix makefile

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.2
+current_version = 0.3.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ release: clean
 	CURRENT_SIGN_SETTING=$(git config commit.gpgSign)
 	git config commit.gpgSign true
 	bumpversion $(bump)
-	git push && git push --tags
+	git push upstream && git push upstream --tags
 	python setup.py sdist bdist_wheel
 	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ deps['dev'] = (
 setup(
     name='eth-keys',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
-    version='0.2.2',
+    version='0.3.0',
     description="""Common API for Ethereum key operations.""",
     long_description_markdown_filename='README.md',
     author='Piper Merriam',


### PR DESCRIPTION
### What was wrong?

None of the stable releases had been pushed to the main repo.

### How was it fixed?

Added `upstream` to the `push` commands in the Makefile

#### Cute Animal Picture

![27db757a54e3b7a69c650232ba996313](https://user-images.githubusercontent.com/824194/59005222-e750dc80-87d9-11e9-98d2-1b9bc4fd6287.jpg)

