### PR TITLE
Fix coincurve backend signature validation

### DIFF
--- a/eth_keys/backends/coincurve.py
+++ b/eth_keys/backends/coincurve.py
@@ -22,6 +22,9 @@ from eth_keys.validation import (
 from eth_keys.utils import (
     der,
 )
+from eth_keys.utils.numeric import (
+    coerce_low_s,
+)
 
 from .base import BaseECCBackend
 
@@ -75,7 +78,8 @@ class CoinCurveECCBackend(BaseECCBackend):
                      msg_hash: bytes,
                      signature: BaseSignature,
                      public_key: PublicKey) -> bool:
-        der_encoded_signature = der.two_int_sequence_encoder(signature.r, signature.s)
+        low_s = coerce_low_s(signature.s)
+        der_encoded_signature = der.two_int_sequence_encoder(signature.r, low_s)
         coincurve_public_key = self.keys.PublicKey(b"\x04" + public_key.to_bytes())
         return coincurve_public_key.verify(
             der_encoded_signature,

--- a/eth_keys/backends/coincurve.py
+++ b/eth_keys/backends/coincurve.py
@@ -78,6 +78,7 @@ class CoinCurveECCBackend(BaseECCBackend):
                      msg_hash: bytes,
                      signature: BaseSignature,
                      public_key: PublicKey) -> bool:
+        # coincurve rejects signatures with a high s, so convert to the equivalent low s form
         low_s = coerce_low_s(signature.s)
         der_encoded_signature = der.two_int_sequence_encoder(signature.r, low_s)
         coincurve_public_key = self.keys.PublicKey(b"\x04" + public_key.to_bytes())

--- a/eth_keys/utils/numeric.py
+++ b/eth_keys/utils/numeric.py
@@ -8,4 +8,9 @@ def int_to_byte(value: int) -> bytes:
 
 
 def coerce_low_s(value: int) -> int:
+    """Coerce the s component of an ECDSA signature into its low-s form.
+
+    See https://bitcoin.stackexchange.com/questions/83408/in-ecdsa-why-is-r-%E2%88%92s-mod-n-complementary-to-r-s  # noqa: W501
+    or https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md.
+    """
     return min(value, -value % SECPK1_N)

--- a/eth_keys/utils/numeric.py
+++ b/eth_keys/utils/numeric.py
@@ -1,2 +1,11 @@
+from eth_keys.constants import (
+    SECPK1_N,
+)
+
+
 def int_to_byte(value: int) -> bytes:
     return bytes([value])
+
+
+def coerce_low_s(value: int) -> int:
+    return min(value, -value % SECPK1_N)

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -61,6 +61,9 @@ def test_ecdsa_sign(key_api, key_fixture):
 def test_ecdsa_sign_non_recoverable(key_api, key_fixture):
     private_key = key_api.PrivateKey(key_fixture['privkey'])
     signature = key_api.ecdsa_sign_non_recoverable(MSGHASH, private_key)
+    non_recoverable_signature = key_api.ecdsa_sign_non_recoverable(MSGHASH, private_key)
+    assert non_recoverable_signature.r == signature.r
+    assert non_recoverable_signature.s == signature.s
 
     assert key_api.ecdsa_verify(MSGHASH, signature, private_key.public_key)
 

--- a/tests/backends/test_native_backend_against_coincurve.py
+++ b/tests/backends/test_native_backend_against_coincurve.py
@@ -104,11 +104,13 @@ def test_native_to_coincurve_recover(private_key_bytes,
     else:
         assert False, "invariant"
 
-    pk_a = backend_a.PrivateKey(private_key_bytes)
-    signature_a = backend_a.ecdsa_sign(message_hash, pk_a)
+    private_key_a = backend_a.PrivateKey(private_key_bytes)
+    public_key_a = private_key_a.public_key
+    signature_a = backend_a.ecdsa_sign(message_hash, private_key_a)
 
     public_key_b = backend_b.ecdsa_recover(message_hash, signature_a)
-    assert public_key_b == pk_a.public_key
+    assert public_key_b == public_key_a
+    assert backend_b.ecdsa_verify(message_hash, signature_a, public_key_b)
 
 
 @given(


### PR DESCRIPTION
### What was wrong?

ECDSA signatures can be represented with a low or a high s: https://bitcoin.stackexchange.com/questions/83408/in-ecdsa-why-is-r-%E2%88%92s-mod-n-complementary-to-r-s

High-s signatures are forbidden in Ethereum, but only since Homestead, so `eth-keys` needs to support both forms. However, Coincurve rejects high-s signatures during verification.

This error was introduced with the non recoverable signatures (prior to this we just recovered the signer and compared, so we didn't use the Coincurve signature verification function).

### How was it fixed?

Convert an incoming high-s signature to its equivalent low-s representation before passing it to coincurve. Also, add some tests for this.

#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/29854669/59109458-5eeb4c80-893d-11e9-9334-e8450f27b650.jpg)
