### PR TITLE
expand-coincurve-testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,24 +66,114 @@ jobs:
       - image: pypy
         environment:
           TOXENV: pypy3-core
-  py35-backends:
+  py35-backends-coincurve7:
     <<: *common
     docker:
       - image: circleci/python:3.5
         environment:
-          TOXENV: py35-backends
-  py36-backends:
+          TOXENV: py35-backends-coincurve7
+  py36-backends-coincurve7:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-backends
-  py37-backends:
+          TOXENV: py36-backends-coincurve7
+  py37-backends-coincurve7:
     <<: *common
     docker:
       - image: circleci/python:3.7
         environment:
-          TOXENV: py37-backends
+          TOXENV: py37-backends-coincurve7
+  py35-backends-coincurve8:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-backends-coincurve8
+  py36-backends-coincurve8:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-backends-coincurve8
+  py37-backends-coincurve8:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-backends-coincurve8
+  py35-backends-coincurve9:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-backends-coincurve9
+  py36-backends-coincurve9:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-backends-coincurve9
+  py37-backends-coincurve9:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-backends-coincurve9
+  py35-backends-coincurve10:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-backends-coincurve10
+  py36-backends-coincurve10:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-backends-coincurve10
+  py37-backends-coincurve10:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-backends-coincurve10
+  py35-backends-coincurve11:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-backends-coincurve11
+  py36-backends-coincurve11:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-backends-coincurve11
+  py37-backends-coincurve11:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-backends-coincurve11
+  py35-backends-coincurve12:
+    <<: *common
+    docker:
+      - image: circleci/python:3.5
+        environment:
+          TOXENV: py35-backends-coincurve12
+  py36-backends-coincurve12:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-backends-coincurve12
+  py37-backends-coincurve12:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-backends-coincurve12
 workflows:
   version: 2
   test:
@@ -95,6 +185,21 @@ workflows:
       - py36-core
       - py37-core
       - pypy3-core
-      - py35-backends
-      - py36-backends
-      - py37-backends
+      - py35-backends-coincurve7
+      - py36-backends-coincurve7
+      - py37-backends-coincurve7
+      - py35-backends-coincurve8
+      - py36-backends-coincurve8
+      - py37-backends-coincurve8
+      - py35-backends-coincurve9
+      - py36-backends-coincurve9
+      - py37-backends-coincurve9
+      - py35-backends-coincurve10
+      - py36-backends-coincurve10
+      - py37-backends-coincurve10
+      - py35-backends-coincurve11
+      - py36-backends-coincurve11
+      - py37-backends-coincurve11
+      - py35-backends-coincurve12
+      - py36-backends-coincurve12
+      - py37-backends-coincurve12

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,9 @@ from setuptools import (
 
 
 deps = {
+    'coincurve': [
+        'coincurve>=7.0.0,<13.0.0',
+    ],
     'eth-keys': [
         "eth-utils>=1.3.0,<2.0.0",
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist=
-    py{35,36,37}-{core,backends}
+    py{35,36,37}-core
+    py{35,36,37}-backends-coincurve{7,8,9,10,11,12}
     pypy3-core
     py{35,36,37}-lint
 
@@ -14,7 +15,12 @@ commands=
     core: py.test {posargs:tests/core}
     backends: py.test {posargs:tests/backends}
 deps = .[test]
-    backends: coincurve>=7.0.0,<8.0.0
+    coincurve7: coincurve>=7.0.0,<8.0.0
+    coincurve8: coincurve>=8.0.0,<9.0.0
+    coincurve9: coincurve>=9.0.0,<10.0.0
+    coincurve10: coincurve>=10.0.0,<11.0.0
+    coincurve11: coincurve>=11.0.0,<12.0.0
+    coincurve12: coincurve>=12.0.0,<13.0.0
 setenv =
     backends: REQUIRE_COINCURVE=True
 basepython =


### PR DESCRIPTION
### What was wrong?

The coincurve library's latest release is `v12.0.0`.  Currently we only test against `>=7.0.0,<8`

### How was it fixed?

Expand test suite in CI to cover every major version range between `>=7.0.0,<13`

#### Cute Animal Picture

![Screen-Shot-2015-07-31-at-10 09 14](https://user-images.githubusercontent.com/824194/63110358-7865d180-bf48-11e9-96c6-6d1c95550679.png)

