### PR TITLE
Remove deprecated import

### DIFF
--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -15,6 +15,9 @@ from typing import (    # noqa: F401
     TYPE_CHECKING,
 )
 
+from eth_typing import (
+    ChecksumAddress,
+)
 from eth_utils import (
     big_endian_to_int,
     encode_hex,
@@ -24,9 +27,6 @@ from eth_utils import (
     keccak,
     to_checksum_address,
     to_normalized_address,
-)
-from eth_utils.typing import (
-    ChecksumAddress,
 )
 
 from eth_keys.utils.address import (

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ deps = {
         "asn1tools>=0.146.2,<0.147",
         "pyasn1>=0.4.5,<0.5",
         'pytest==3.2.2',
-        'hypothesis==3.30.0',
+        'hypothesis>=4.56.1, <5.0.0',
         "eth-hash[pysha3];implementation_name=='cpython'",
         "eth-hash[pycryptodome];implementation_name=='pypy'",
     ],

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ deps = {
     ],
     'eth-keys': [
         "eth-utils>=1.3.0,<2.0.0",
+        "eth-typing>=2.2.1,<3.0.0",
     ],
     'test': [
         "asn1tools>=0.146.2,<0.147",


### PR DESCRIPTION
### What was wrong?

We are importing from a deprecated library causing warnings in downstream projects such as Trinity.

```
/home/cburgdorf/Documents/hacking/ef/trinity/venv/lib/python3.7/site-packages/eth_keys/datatypes.py:28: DeprecationWarning: The eth_utils.typing module will be deprecated in favor of eth-typing in the next major version bump.
  from eth_utils.typing import (
```

### How was it fixed?

Add `eth-typing` dependency and use `ChecksumAddress` from there.

#### Cute Animal Picture

![Cute animal picture](https://www.desktopbackground.org/p/2015/04/29/940614_baby-cheetah-cubs-kittens-wallpapers-free-full-hd-wallpapers-for_1366x768_h.jpg)
