### PR TITLE
Officially support Python 3.8, with tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
   pypy3-core:
     <<: *common
     docker:
@@ -72,6 +78,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-backends-coincurve7
+  py38-backends-coincurve7:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-backends-coincurve7
   py35-backends-coincurve8:
     <<: *common
     docker:
@@ -90,6 +102,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-backends-coincurve8
+  py38-backends-coincurve8:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-backends-coincurve8
   py35-backends-coincurve9:
     <<: *common
     docker:
@@ -108,6 +126,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-backends-coincurve9
+  py38-backends-coincurve9:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-backends-coincurve9
   py35-backends-coincurve10:
     <<: *common
     docker:
@@ -126,6 +150,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-backends-coincurve10
+  py38-backends-coincurve10:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-backends-coincurve10
   py35-backends-coincurve11:
     <<: *common
     docker:
@@ -144,6 +174,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-backends-coincurve11
+  py38-backends-coincurve11:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-backends-coincurve11
   py35-backends-coincurve12:
     <<: *common
     docker:
@@ -162,6 +198,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-backends-coincurve12
+  py38-backends-coincurve12:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-backends-coincurve12
 workflows:
   version: 2
   test:
@@ -170,22 +212,29 @@ workflows:
       - py35-core
       - py36-core
       - py37-core
+      - py38-core
       - pypy3-core
       - py35-backends-coincurve7
       - py36-backends-coincurve7
       - py37-backends-coincurve7
+      - py38-backends-coincurve7
       - py35-backends-coincurve8
       - py36-backends-coincurve8
       - py37-backends-coincurve8
+      - py38-backends-coincurve8
       - py35-backends-coincurve9
       - py36-backends-coincurve9
       - py37-backends-coincurve9
+      - py38-backends-coincurve9
       - py35-backends-coincurve10
       - py36-backends-coincurve10
       - py37-backends-coincurve10
+      - py38-backends-coincurve10
       - py35-backends-coincurve11
       - py36-backends-coincurve11
       - py37-backends-coincurve11
+      - py38-backends-coincurve11
       - py35-backends-coincurve12
       - py36-backends-coincurve12
       - py37-backends-coincurve12
+      - py38-backends-coincurve12

--- a/setup.py
+++ b/setup.py
@@ -68,5 +68,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -67,5 +67,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{35,36,37}-core
-    py{35,36,37}-backends-coincurve{7,8,9,10,11,12}
+    py{35,36,37,38}-core
+    py{35,36,37,38}-backends-coincurve{7,8,9,10,11,12}
     pypy3-core
     lint
 
@@ -27,6 +27,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
     pypy3: pypy3
 
 [testenv:lint]


### PR DESCRIPTION
### What was wrong?
Add Python 3.8 support.
Also, noted the missing PyPI identifier for Python 3.7 support.

### How was it fixed?
Tests pass locally, but there was is a lot of tox combinations, decided to let it run to see if anything happens.

#### Cute Animal Picture
![clueless monkey](https://www.storytrender.com/wp-content/uploads/2018/01/0_CATERS_CLUELESS_MONKEY_01-768x512.jpg)