### PR TITLE
Use ValidationError from eth_utils

### DIFF
--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -27,6 +27,8 @@ from eth_utils import (
     keccak,
     to_checksum_address,
     to_normalized_address,
+    ValidationError,
+
 )
 
 from eth_keys.utils.address import (
@@ -41,7 +43,6 @@ from eth_keys.utils.padding import (
 
 from eth_keys.exceptions import (
     BadSignature,
-    ValidationError,
 )
 from eth_keys.validation import (
     validate_private_key_bytes,

--- a/eth_keys/exceptions.py
+++ b/eth_keys/exceptions.py
@@ -1,6 +1,2 @@
-class ValidationError(Exception):
-    pass
-
-
 class BadSignature(Exception):
     pass

--- a/eth_keys/main.py
+++ b/eth_keys/main.py
@@ -1,5 +1,10 @@
 from typing import (Any, Union, Type)  # noqa: F401
 
+from eth_utils import (
+    is_string,
+    ValidationError,
+)
+
 from eth_keys.datatypes import (
     BaseSignature,
     LazyBackend,
@@ -7,9 +12,6 @@ from eth_keys.datatypes import (
     PublicKey,
     PrivateKey,
     Signature,
-)
-from eth_keys.exceptions import (
-    ValidationError,
 )
 from eth_keys.validation import (
     validate_message_hash,

--- a/eth_keys/validation.py
+++ b/eth_keys/validation.py
@@ -4,14 +4,12 @@ from eth_utils import (
     encode_hex,
     is_bytes,
     is_integer,
+    ValidationError,
 )
 from eth_utils.toolz import curry
 
 from eth_keys.constants import (
     SECPK1_N,
-)
-from eth_keys.exceptions import (
-    ValidationError,
 )
 
 

--- a/tests/core/test_key_and_signature_datastructures.py
+++ b/tests/core/test_key_and_signature_datastructures.py
@@ -10,13 +10,11 @@ from eth_utils import (
     is_normalized_address,
     is_checksum_address,
     is_canonical_address,
+    ValidationError,
 )
 
 from eth_keys import KeyAPI
 from eth_keys.backends import NativeECCBackend
-from eth_keys.exceptions import (
-    ValidationError,
-)
 
 
 MSG = b'message'

--- a/tests/core/test_key_api_proxy_methods.py
+++ b/tests/core/test_key_api_proxy_methods.py
@@ -2,11 +2,11 @@ import pytest
 
 from eth_utils import (
     keccak,
+    ValidationError,
 )
 
 from eth_keys import KeyAPI
 from eth_keys.backends import NativeECCBackend
-from eth_keys.exceptions import ValidationError
 
 
 MSG = b'message'


### PR DESCRIPTION
Having a ValidationError defined both here and there makes no sense
and forces callsites to catch them both in some situations.