### PR TITLE
Expose ValidationError for backwards compatibility

### DIFF
--- a/eth_keys/exceptions.py
+++ b/eth_keys/exceptions.py
@@ -1,2 +1,7 @@
+# This exposes the eth-utils exception for backwards compatibility,
+# for any library that catches eth_keys.exceptions.ValidationError
+from eth_utils import ValidationError  # noqa: F401
+
+
 class BadSignature(Exception):
     pass


### PR DESCRIPTION
### What was wrong?

https://github.com/ethereum/eth-keys/pull/68#issuecomment-618031734

### How was it fixed?

Re-add `ValidationError` at `eth_keys.exceptions.ValidationError`, but using the eth-utils version.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/36/d4/72/36d4728171e3a9e6ff8e69f0ee7f4b01.jpg)
