### PR TITLE
Enable lint tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,24 +24,12 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  py35-lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-lint
-  py36-lint:
+  lint:
     <<: *common
     docker:
       - image: circleci/python:3.6
         environment:
-          TOXENV: py36-lint
-  py37-lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.7
-        environment:
-          TOXENV: py37-lint
+          TOXENV: lint
   py35-core:
     <<: *common
     docker:
@@ -178,9 +166,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - py35-lint
-      - py36-lint
-      - py37-lint
+      - lint
       - py35-core
       - py36-core
       - py37-core

--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -9,7 +9,6 @@ import collections
 import sys
 from typing import (    # noqa: F401
     Any,
-    cast,
     Tuple,
     Union,
     Type,
@@ -235,9 +234,7 @@ class PublicKey(BaseKey, LazyBackend):
     # Ethereum address conversions
     #
     def to_checksum_address(self) -> ChecksumAddress:
-        canonical_address = public_key_bytes_to_address(self.to_bytes())
-        # TODO: drop cast after to_checksum_address() returns eth_typing.evm.ChecksumAddress
-        return cast(ChecksumAddress, to_checksum_address(canonical_address))
+        return to_checksum_address(public_key_bytes_to_address(self.to_bytes()))
 
     def to_address(self) -> str:
         return to_normalized_address(public_key_bytes_to_address(self.to_bytes()))

--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -9,6 +9,7 @@ import collections
 import sys
 from typing import (    # noqa: F401
     Any,
+    cast,
     Tuple,
     Union,
     Type,
@@ -234,7 +235,9 @@ class PublicKey(BaseKey, LazyBackend):
     # Ethereum address conversions
     #
     def to_checksum_address(self) -> ChecksumAddress:
-        return to_checksum_address(public_key_bytes_to_address(self.to_bytes()))
+        canonical_address = public_key_bytes_to_address(self.to_bytes())
+        # TODO: drop cast after to_checksum_address() returns eth_typing.evm.ChecksumAddress
+        return cast(ChecksumAddress, to_checksum_address(canonical_address))
 
     def to_address(self) -> str:
         return to_normalized_address(public_key_bytes_to_address(self.to_bytes()))
@@ -395,12 +398,12 @@ class Signature(BaseSignature):
         validate_signature_v(value)
         self._v = value
 
-    @BaseSignature.r.setter
+    @BaseSignature.r.setter  # type: ignore
     def r(self, value: int) -> None:
         validate_signature_r_or_s(value)
         self._r = value
 
-    @BaseSignature.s.setter
+    @BaseSignature.s.setter  # type: ignore
     def s(self, value: int) -> None:
         validate_signature_r_or_s(value)
         self._s = value
@@ -446,7 +449,7 @@ class NonRecoverableSignature(BaseSignature):
 
         super().__init__(rs=(r, s), backend=backend)
 
-    def to_bytes(self):
+    def to_bytes(self) -> bytes:
         return b''.join(
             pad32(int_to_big_endian(value))
             for value in self.rs

--- a/eth_keys/main.py
+++ b/eth_keys/main.py
@@ -1,7 +1,6 @@
 from typing import (Any, Union, Type)  # noqa: F401
 
 from eth_utils import (
-    is_string,
     ValidationError,
 )
 
@@ -15,8 +14,6 @@ from eth_keys.datatypes import (
 )
 from eth_keys.validation import (
     validate_message_hash,
-    validate_compressed_public_key_bytes,
-    validate_uncompressed_public_key_bytes,
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ deps = {
         'coincurve>=7.0.0,<13.0.0',
     ],
     'eth-keys': [
-        "eth-utils>=1.3.0,<2.0.0",
+        "eth-utils>=1.8.2,<2.0.0",
         "eth-typing>=2.2.1,<3.0.0",
     ],
     'test': [

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=
     py{35,36,37}-core
     py{35,36,37}-backends-coincurve{7,8,9,10,11,12}
     pypy3-core
-    py{35,36,37}-lint
+    lint
 
 [flake8]
 max-line-length= 100
@@ -30,10 +30,7 @@ basepython =
     pypy3: pypy3
 
 [testenv:lint]
-basepython =
-    py35: python3.5
-    py36: python3.6
-    py37: python3.7
+basepython = python3.6
 deps=.[lint]
 commands=
     flake8 {toxinidir}/eth_keys {toxinidir}/setup.py


### PR DESCRIPTION
### What was wrong?

Lint tests were not running in CI

### How was it fixed?

The tox config file was broken. I don't think we really need to run lint in every python environment, which makes it a lot harder to maintain a (correct) tox.ini. So this just collapses down to a single lint test.

Also, fixed some flake8 and mypy failures had built up over time.

#### Cute Animal Picture

![Cute animal picture](https://cdn.shopify.com/s/files/1/0601/4169/files/Cuteoff_top_large.jpg?16879535961147076756)
