### PR TITLE
add factories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	flake8 eth_keys
+	tox -e lint
 
 test:
 	py.test tests

--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -117,9 +117,7 @@ class BaseKey(ByteString, collections.abc.Hashable):
     _raw_key = None  # type: bytes
 
     def to_hex(self) -> str:
-        # Need the 'type: ignore' comment below because of
-        # https://github.com/python/typeshed/issues/300
-        return '0x' + codecs.decode(codecs.encode(self._raw_key, 'hex'), 'ascii')  # type: ignore
+        return '0x' + codecs.decode(codecs.encode(self._raw_key, 'hex'), 'ascii')
 
     def to_bytes(self) -> bytes:
         return self._raw_key

--- a/eth_keys/tools/factories.py
+++ b/eth_keys/tools/factories.py
@@ -1,0 +1,33 @@
+try:
+    import factory
+except ImportError as err:
+    raise ImportError(
+        "Use of `eth_keys.tools.factories` requires the `factory-boy` package "
+        "which does not appear to be installed."
+    ) from err
+
+from eth_keys import keys
+
+
+def _mk_random_bytes(num_bytes: int) -> bytes:
+    try:
+        import secrets
+    except ImportError:
+        import os
+        return os.urandom(num_bytes)
+    else:
+        return secrets.token_bytes(num_bytes)
+
+
+class PrivateKeyFactory(factory.Factory):  # type: ignore
+    class Meta:
+        model = keys.PrivateKey
+
+    private_key_bytes = factory.LazyFunction(lambda: _mk_random_bytes(32))
+
+
+class PublicKeyFactory(factory.Factory):  # type: ignore
+    class Meta:
+        model = keys.PublicKey
+
+    public_key_bytes = factory.LazyFunction(lambda: PrivateKeyFactory().public_key.to_bytes())

--- a/eth_keys/utils/numeric.py
+++ b/eth_keys/utils/numeric.py
@@ -10,7 +10,7 @@ def int_to_byte(value: int) -> bytes:
 def coerce_low_s(value: int) -> int:
     """Coerce the s component of an ECDSA signature into its low-s form.
 
-    See https://bitcoin.stackexchange.com/questions/83408/in-ecdsa-why-is-r-%E2%88%92s-mod-n-complementary-to-r-s  # noqa: W501
+    See https://bitcoin.stackexchange.com/questions/83408/in-ecdsa-why-is-r-%E2%88%92s-mod-n-complementary-to-r-s  # noqa: E501
     or https://github.com/ethereum/EIPs/blob/master/EIPS/eip-2.md.
     """
     return min(value, -value % SECPK1_N)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ deps = {
     ],
     'test': [
         "asn1tools>=0.146.2,<0.147",
+        "factory-boy>=3.0.1,<3.1",
         "pyasn1>=0.4.5,<0.5",
         "pytest==5.4.1",
         "hypothesis>=5.10.3, <6.0.0",
@@ -24,10 +25,10 @@ deps = {
     ],
     'lint': [
         'flake8==3.0.4',
-        'mypy==0.701',
+        'mypy==0.782',
     ],
     'dev': [
-        'tox==2.7.0',
+        'tox==3.20.0',
         'bumpversion==0.5.3',
         'twine',
     ],
@@ -40,17 +41,20 @@ deps['dev'] = (
     deps['test']
 )
 
+with open('./README.md') as readme:
+    long_description = readme.read()
+
 setup(
     name='eth-keys',
     # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version='0.3.3',
     description="""Common API for Ethereum key operations.""",
-    long_description_markdown_filename='README.md',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     author='Piper Merriam',
     author_email='pipermerriam@gmail.com',
     url='https://github.com/ethereum/eth-keys',
     include_package_data=True,
-    setup_requires=['setuptools-markdown'],
     install_requires=deps['eth-keys'],
     py_modules=['eth_keys'],
     extras_require=deps,

--- a/tests/core/test_factories.py
+++ b/tests/core/test_factories.py
@@ -1,0 +1,15 @@
+from eth_keys import keys
+from eth_keys.tools.factories import (
+    PrivateKeyFactory,
+    PublicKeyFactory,
+)
+
+
+def test_private_key_factory():
+    actual = PrivateKeyFactory()
+    assert actual == keys.PrivateKey(actual.to_bytes())
+
+
+def test_public_key_factory():
+    actual = PublicKeyFactory()
+    assert actual == keys.PublicKey(actual.to_bytes())


### PR DESCRIPTION
### What was wrong?

We have a few repositories where we've created `PrivateKeyFactory` and `PublicKeyFactory`.  It would be nice to just import them from here

### How was it fixed?

Added `eth_keys.tools.factories` which has factory classes for both `PublicKey` and `PrivateKey`

I also ended up needing to upgrade some testing dependencies.


#### Cute Animal Picture

![confused-funny-giraffe](https://user-images.githubusercontent.com/824194/92009137-4c5cf000-ed05-11ea-87d0-77c5e38a3728.jpg)

