### PR TITLE
Update eth-utils and eth-typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ deps = {
         'coincurve>=7.0.0,<16.0.0',
     ],
     'eth-keys': [
-        "eth-utils>=1.8.2,<2.0.0",
-        "eth-typing>=2.2.1,<3.0.0",
+        "eth-utils>=2.0.0,<3.0.0",
+        "eth-typing>=3.0.0,<4",
     ],
     'test': [
         "asn1tools>=0.146.2,<0.147",


### PR DESCRIPTION

### What was wrong?

I updated `eth-utils` and `eth-typing` to drop python 3.5 support. So need to update here too. 


### How was it fixed?

Updated `eth-utils` and `eth-typing` version requirements.

#### Cute Animal Picture

![Cute animal picture](https://townsquare.media/site/341/files/2011/12/turkey-and-dear.jpg?w=980&q=75)
