### PR TITLE
Update python support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,6 +246,96 @@ jobs:
       - image: circleci/python:3.10
         environment:
           TOXENV: py310-backends-coincurve12
+  py36-backends-coincurve13:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-backends-coincurve13
+  py37-backends-coincurve13:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-backends-coincurve13
+  py38-backends-coincurve13:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-backends-coincurve13
+  py39-backends-coincurve13:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve13
+  py310-backends-coincurve13:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve13
+  py36-backends-coincurve14:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-backends-coincurve14
+  py37-backends-coincurve14:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-backends-coincurve14
+  py38-backends-coincurve14:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-backends-coincurve14
+  py39-backends-coincurve14:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve14
+  py310-backends-coincurve14:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve14
+  py36-backends-coincurve15:
+    <<: *common
+    docker:
+      - image: circleci/python:3.6
+        environment:
+          TOXENV: py36-backends-coincurve15
+  py37-backends-coincurve15:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-backends-coincurve15
+  py38-backends-coincurve15:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-backends-coincurve15
+  py39-backends-coincurve15:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve15
+  py310-backends-coincurve15:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve15
 workflows:
   version: 2
   test:
@@ -287,3 +377,18 @@ workflows:
       - py38-backends-coincurve12
       - py39-backends-coincurve12
       - py310-backends-coincurve12
+      - py36-backends-coincurve13
+      - py37-backends-coincurve13
+      - py38-backends-coincurve13
+      - py39-backends-coincurve13
+      - py310-backends-coincurve13
+      - py36-backends-coincurve14
+      - py37-backends-coincurve14
+      - py38-backends-coincurve14
+      - py39-backends-coincurve14
+      - py310-backends-coincurve14
+      - py36-backends-coincurve15
+      - py37-backends-coincurve15
+      - py38-backends-coincurve15
+      - py39-backends-coincurve15
+      - py310-backends-coincurve15

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
   pypy3-core:
     <<: *common
     docker:
@@ -72,6 +78,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve7
+  py39-backends-coincurve7:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve7
   py36-backends-coincurve8:
     <<: *common
     docker:
@@ -90,6 +102,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve8
+  py39-backends-coincurve8:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve8
   py36-backends-coincurve9:
     <<: *common
     docker:
@@ -108,6 +126,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve9
+  py39-backends-coincurve9:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve9
   py36-backends-coincurve10:
     <<: *common
     docker:
@@ -126,6 +150,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve10
+  py39-backends-coincurve10:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve10
   py36-backends-coincurve11:
     <<: *common
     docker:
@@ -144,6 +174,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve11
+  py39-backends-coincurve11:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve11
   py36-backends-coincurve12:
     <<: *common
     docker:
@@ -162,6 +198,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve12
+  py39-backends-coincurve12:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve12
 workflows:
   version: 2
   test:
@@ -170,22 +212,29 @@ workflows:
       - py36-core
       - py37-core
       - py38-core
+      - py39-core
       - pypy3-core
       - py36-backends-coincurve7
       - py37-backends-coincurve7
       - py38-backends-coincurve7
+      - py39-backends-coincurve7
       - py36-backends-coincurve8
       - py37-backends-coincurve8
       - py38-backends-coincurve8
+      - py39-backends-coincurve8
       - py36-backends-coincurve9
       - py37-backends-coincurve9
       - py38-backends-coincurve9
+      - py39-backends-coincurve9
       - py36-backends-coincurve10
       - py37-backends-coincurve10
       - py38-backends-coincurve10
+      - py39-backends-coincurve10
       - py36-backends-coincurve11
       - py37-backends-coincurve11
       - py38-backends-coincurve11
+      - py39-backends-coincurve11
       - py36-backends-coincurve12
       - py37-backends-coincurve12
       - py38-backends-coincurve12
+      - py39-backends-coincurve12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,12 +30,6 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: lint
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-core
   py36-core:
     <<: *common
     docker:
@@ -60,12 +54,6 @@ jobs:
       - image: pypy
         environment:
           TOXENV: pypy3-core
-  py35-backends-coincurve7:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-backends-coincurve7
   py36-backends-coincurve7:
     <<: *common
     docker:
@@ -84,12 +72,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve7
-  py35-backends-coincurve8:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-backends-coincurve8
   py36-backends-coincurve8:
     <<: *common
     docker:
@@ -108,12 +90,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve8
-  py35-backends-coincurve9:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-backends-coincurve9
   py36-backends-coincurve9:
     <<: *common
     docker:
@@ -132,12 +108,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve9
-  py35-backends-coincurve10:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-backends-coincurve10
   py36-backends-coincurve10:
     <<: *common
     docker:
@@ -156,12 +126,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve10
-  py35-backends-coincurve11:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-backends-coincurve11
   py36-backends-coincurve11:
     <<: *common
     docker:
@@ -180,12 +144,6 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-backends-coincurve11
-  py35-backends-coincurve12:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-backends-coincurve12
   py36-backends-coincurve12:
     <<: *common
     docker:
@@ -209,32 +167,25 @@ workflows:
   test:
     jobs:
       - lint
-      - py35-core
       - py36-core
       - py37-core
       - py38-core
       - pypy3-core
-      - py35-backends-coincurve7
       - py36-backends-coincurve7
       - py37-backends-coincurve7
       - py38-backends-coincurve7
-      - py35-backends-coincurve8
       - py36-backends-coincurve8
       - py37-backends-coincurve8
       - py38-backends-coincurve8
-      - py35-backends-coincurve9
       - py36-backends-coincurve9
       - py37-backends-coincurve9
       - py38-backends-coincurve9
-      - py35-backends-coincurve10
       - py36-backends-coincurve10
       - py37-backends-coincurve10
       - py38-backends-coincurve10
-      - py35-backends-coincurve11
       - py36-backends-coincurve11
       - py37-backends-coincurve11
       - py38-backends-coincurve11
-      - py35-backends-coincurve12
       - py36-backends-coincurve12
       - py37-backends-coincurve12
       - py38-backends-coincurve12

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core
+  py310-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core
   pypy3-core:
     <<: *common
     docker:
@@ -84,6 +90,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-backends-coincurve7
+  py310-backends-coincurve7:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve7
   py36-backends-coincurve8:
     <<: *common
     docker:
@@ -108,6 +120,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-backends-coincurve8
+  py310-backends-coincurve8:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve8
   py36-backends-coincurve9:
     <<: *common
     docker:
@@ -132,6 +150,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-backends-coincurve9
+  py310-backends-coincurve9:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve9
   py36-backends-coincurve10:
     <<: *common
     docker:
@@ -156,6 +180,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-backends-coincurve10
+  py310-backends-coincurve10:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve10
   py36-backends-coincurve11:
     <<: *common
     docker:
@@ -180,6 +210,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-backends-coincurve11
+  py310-backends-coincurve11:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve11
   py36-backends-coincurve12:
     <<: *common
     docker:
@@ -204,6 +240,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-backends-coincurve12
+  py310-backends-coincurve12:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve12
 workflows:
   version: 2
   test:
@@ -213,28 +255,35 @@ workflows:
       - py37-core
       - py38-core
       - py39-core
+      - py310-core
       - pypy3-core
       - py36-backends-coincurve7
       - py37-backends-coincurve7
       - py38-backends-coincurve7
       - py39-backends-coincurve7
+      - py310-backends-coincurve7
       - py36-backends-coincurve8
       - py37-backends-coincurve8
       - py38-backends-coincurve8
       - py39-backends-coincurve8
+      - py310-backends-coincurve8
       - py36-backends-coincurve9
       - py37-backends-coincurve9
       - py38-backends-coincurve9
       - py39-backends-coincurve9
+      - py310-backends-coincurve9
       - py36-backends-coincurve10
       - py37-backends-coincurve10
       - py38-backends-coincurve10
       - py39-backends-coincurve10
+      - py310-backends-coincurve10
       - py36-backends-coincurve11
       - py37-backends-coincurve11
       - py38-backends-coincurve11
       - py39-backends-coincurve11
+      - py310-backends-coincurve11
       - py36-backends-coincurve12
       - py37-backends-coincurve12
       - py38-backends-coincurve12
       - py39-backends-coincurve12
+      - py310-backends-coincurve12

--- a/setup.py
+++ b/setup.py
@@ -73,5 +73,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ deps = {
         "asn1tools>=0.146.2,<0.147",
         "factory-boy>=3.0.1,<3.1",
         "pyasn1>=0.4.5,<0.5",
-        "pytest==5.4.1",
+        "pytest==6.2.5",
         "hypothesis>=5.10.3, <6.0.0",
         "eth-hash[pysha3];implementation_name=='cpython'",
         "eth-hash[pycryptodome];implementation_name=='pypy'",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import (
 
 deps = {
     'coincurve': [
-        'coincurve>=7.0.0,<13.0.0',
+        'coincurve>=7.0.0,<16.0.0',
     ],
     'eth-keys': [
         "eth-utils>=1.8.2,<2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/tests/backends/test_backends.py
+++ b/tests/backends/test_backends.py
@@ -46,7 +46,7 @@ def backend_id_fn(backend):
     return type(backend).__name__
 
 
-@pytest.fixture(params=backends, ids=backend_id_fn)
+@pytest.fixture(params=backends, ids=backend_id_fn, scope='module')
 def key_api(request):
     return KeyAPI(backend=request.param)
 

--- a/tests/backends/test_native_backend_against_coincurve.py
+++ b/tests/backends/test_native_backend_against_coincurve.py
@@ -31,12 +31,12 @@ MSGHASH = keccak(MSG)
 MAX_EXAMPLES = 200
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def native_key_api():
     return KeyAPI(backend=NativeECCBackend())
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def coincurve_key_api():
     return KeyAPI(backend=CoinCurveECCBackend())
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{35,36,37,38}-core
-    py{35,36,37,38}-backends-coincurve{7,8,9,10,11,12}
+    py{36,37,38}-core
+    py{36,37,38}-backends-coincurve{7,8,9,10,11,12}
     pypy3-core
     lint
 
@@ -24,7 +24,6 @@ deps = .[test]
 setenv =
     backends: REQUIRE_COINCURVE=True
 basepython =
-    py35: python3.5
     py36: python3.6
     py37: python3.7
     py38: python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
     py{36,37,38,39,310}-core
-    py{36,37,38,39,310}-backends-coincurve{7,8,9,10,11,12}
+    py{36,37,38,39,310}-backends-coincurve{7,8,9,10,11,12,13,14,15}
     pypy3-core
     lint
 
@@ -21,6 +21,9 @@ deps = .[test]
     coincurve10: coincurve>=10.0.0,<11.0.0
     coincurve11: coincurve>=11.0.0,<12.0.0
     coincurve12: coincurve>=12.0.0,<13.0.0
+    coincurve13: coincurve>=13.0.0,<14.0.0
+    coincurve14: coincurve>=14.0.0,<15.0.0
+    coincurve15: coincurve>=15.0.0,<16.0.0
 setenv =
     backends: REQUIRE_COINCURVE=True
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37,38}-core
-    py{36,37,38}-backends-coincurve{7,8,9,10,11,12}
+    py{36,37,38,39}-core
+    py{36,37,38,39}-backends-coincurve{7,8,9,10,11,12}
     pypy3-core
     lint
 
@@ -27,6 +27,7 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
     pypy3: pypy3
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37,38,39}-core
-    py{36,37,38,39}-backends-coincurve{7,8,9,10,11,12}
+    py{36,37,38,39,310}-core
+    py{36,37,38,39,310}-backends-coincurve{7,8,9,10,11,12}
     pypy3-core
     lint
 
@@ -28,6 +28,7 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10
     pypy3: pypy3
 
 [testenv:lint]


### PR DESCRIPTION
### What was wrong?

Python 3.5 is no longer supported. 


### How was it fixed?

Dropped python 3.5, added support for python 3.9 and 3.10. Also added coincurve tests through v15, but not sure if I should drop past versions.


#### Cute Animal Picture

![Cute animal picture](https://mfacdn.cachefly.net/chooseveg/2014/11/Baby_Turkey_Vegetarian-2.jpg)
