### PR TITLE
Fixed package_data configuration to include py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     extras_require=deps,
     license="MIT",
     zip_safe=False,
-    package_data={'eth-keys': ['py.typed']},
+    package_data={'eth_keys': ['py.typed']},
     keywords='ethereum',
     packages=find_packages(exclude=["tests", "tests.*"]),
     classifiers=[


### PR DESCRIPTION
### What was wrong?

`package_data` was not configured with the correct package name causing `py.typed` to be non included in the package and preventing mypy to correctly consider the module as typed

### How was it fixed?

Changed the wrong package name (`eth-keys`) with the correct name (`eth_keys`) in `setup.py`


#### Cute Animal Picture

![Cute animal picture](https://user-images.githubusercontent.com/12394806/180945694-8eeccc77-39f5-42db-a39f-9dbf4638230c.jpeg)
