### PR TITLE
set ecdsa_raw_recover to accept 0 or 1 as valid v values

### DIFF
--- a/eth_keys/backends/native/ecdsa.py
+++ b/eth_keys/backends/native/ecdsa.py
@@ -154,7 +154,7 @@ def ecdsa_raw_recover(msg_hash: bytes, vrs: Tuple[int, int, int]) -> bytes:
     v, r, s = vrs
 
     if v not in (0, 1):
-        raise BadSignature(f"{v} must be either 0 or 1")
+        raise BadSignature(f"value of v, aka y-parity, was {v}, must be either 0 or 1")
 
     v += 27
     x = r

--- a/eth_keys/backends/native/ecdsa.py
+++ b/eth_keys/backends/native/ecdsa.py
@@ -152,11 +152,11 @@ def ecdsa_raw_verify(
 
 def ecdsa_raw_recover(msg_hash: bytes, vrs: Tuple[int, int, int]) -> bytes:
     v, r, s = vrs
+
+    if v not in (0, 1):
+        raise BadSignature(f"{v} must be either 0 or 1")
+
     v += 27
-
-    if not (27 <= v <= 34):
-        raise BadSignature(f"{v} must in range 27-31")
-
     x = r
 
     xcubedaxb = (x * x * x + A * x + B) % P

--- a/newsfragments/100.breaking.rst
+++ b/newsfragments/100.breaking.rst
@@ -1,0 +1,1 @@
+Set ``ecdsa_raw_recover`` to accept ``v`` values of 0 or 1


### PR DESCRIPTION
### What was wrong?

In `ecdsa_raw_recover`, the value check for `v` looked for  `27 <= v <=34, while the error message indicated 27-31.

Closes #67 

### How was it fixed?

~~I believe the intended check should be looking for a `v` value of 27-30 inclusive, meaning the argument to the function should be in [0, 1, 2, 3]. This would be consistent with the error message, taking the python sense of range of lower number inclusive, higher number exclusive. I've clarified the error message range and used `0-3` instead of `27-30`, as that is what the arg passed to the function would be.~~

On the actual value check, I'm unable to find any reference to a `v` value in [27-34]. Pre-EIP155 Ethereum used [0-1], other "standard" implementations use [0-3], and post-EIP155 Ethereum uses `{0,1} + CHAIN_ID * 2 + 35`. This function looks like it was written to accept [0-3], but in testing other functions in the same file, I'm not able to generate a `v` other that 0 or 1.

It would be great to update to work with post-EIP155 `v` values, but that would need more research to see what else is affected. Out of scope for this PR.

Updated: Setting to accept only values of 0 or 1, in line with the pre-EIP155 Ethereum-specific standard.

This same bug exists in `py_ecc` - https://github.com/ethereum/py_ecc/blob/93edf6d654c06fff017ba77a103d59aae48edcd7/py_ecc/secp256k1/secp256k1.py#L262

Once merged, I'll make the same fix there.

 - https://eips.ethereum.org/EIPS/eip-155
 - https://bitcoin.stackexchange.com/questions/38351/ecdsa-v-r-s-what-is-v
 - https://docs.rs/k256/latest/k256/ecdsa/struct.RecoveryId.html

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-keys/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/d69279f6-3725-4669-81a0-5b1f31ad118e)
