### PR TITLE
fix: mod reduce msg_hash as input of the HMAC function 

### DIFF
--- a/eth_keys/backends/native/ecdsa.py
+++ b/eth_keys/backends/native/ecdsa.py
@@ -121,7 +121,8 @@ def deterministic_generate_k(
 
 def ecdsa_raw_sign(msg_hash: bytes, private_key_bytes: bytes) -> Tuple[int, int, int]:
     z = big_endian_to_int(msg_hash)
-    k = deterministic_generate_k(msg_hash, private_key_bytes)
+    msg_hash_mod_n = pad32(int_to_big_endian(z % N))
+    k = deterministic_generate_k(msg_hash_mod_n, private_key_bytes)
 
     r, y = fast_multiply(G, k)
     s_raw = inv(k, N) * (z + r * big_endian_to_int(private_key_bytes)) % N

--- a/newsfragments/101.bugfix.rst
+++ b/newsfragments/101.bugfix.rst
@@ -1,0 +1,1 @@
+Modulo reduce the message digest before passing it to the HMAC function

--- a/tests/backends/test_native_backend_against_coincurve.py
+++ b/tests/backends/test_native_backend_against_coincurve.py
@@ -1,9 +1,11 @@
 import pytest
 
 from eth_utils import (
+    int_to_big_endian,
     keccak,
 )
 from hypothesis import (
+    example,
     given,
     settings,
     strategies as st,
@@ -21,8 +23,14 @@ from eth_keys.backends import (
     CoinCurveECCBackend,
     NativeECCBackend,
 )
+from eth_keys.constants import (
+    SECPK1_N,
+)
 from eth_keys.exceptions import (
     BadSignature,
+)
+from eth_keys.utils.padding import (
+    pad32,
 )
 
 MSG = b"message"
@@ -57,6 +65,10 @@ def test_public_key_generation_is_equal(
 @given(
     private_key_bytes=private_key_st,
     message_hash=message_hash_st,
+)
+@example(
+    private_key_bytes=pad32(int_to_big_endian(1)),
+    message_hash=int_to_big_endian(SECPK1_N),
 )
 @settings(max_examples=MAX_EXAMPLES)
 def test_signing_is_equal(


### PR DESCRIPTION
### What was wrong?
Eth-keys did not fully respect [RFC6979 3.2.d](https://datatracker.ietf.org/doc/html/rfc6979#section-3.2).
The message digest should be modulo reduced before being passed as input of HMAC function.
This issue was found after [this analysis](https://github.com/obatirou/RFC6979-implementation-analysis?tab=readme-ov-file).

According to the RFC, it should pass through a `bits2octets` function:
```bash
 K = HMAC_K(V || 0x01 || int2octets(x) || bits2octets(h1))
```

By looking into the definition of `bits2octets`, it states that the message digest needs to be reduced:

```bash
2.3.4.  Bit String to Octet String

   The bits2octets transform takes as input a sequence of blen bits and
   outputs a sequence of rlen bits.  It consists of the following steps:

   1.  The input sequence b is converted into an integer value z1
       through the bits2int transform:

          z1 = bits2int(b)

   2.  z1 is reduced modulo q, yielding z2 (an integer between 0 and
       q-1, inclusive):

          z2 = z1 mod q
   ...
```

Closes #101

### How was it fixed?


### Todo:

- [X] Clean up commit history
- [X] Add or update documentation related to these changes
- [X] Add entry to the [release notes](https://github.com/ethereum/eth-keys/blob/main/newsfragments/README.md)
