### PR TITLE
remove duplicate clean line in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ help:
 	@echo "notes - consume towncrier newsfragments/ and update CHANGELOG - requires bump to be set"
 	@echo "release - package and upload a release (does not run notes target) - requires bump to be set"
 
-clean: clean-build clean-pyc
-
 clean-build:
 	rm -fr build/
 	rm -fr dist/


### PR DESCRIPTION
### What was wrong?

Noticed a line in Makefile was duplicated (line 17 and line 30) with the last template update. Deleted it.

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-keys/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/fe4e3cda-8634-4e2f-ae09-dabf29f6b026)
