### PR TITLE
fix bugs in PrivateKey

### DIFF
--- a/eth_keys/datatypes.py
+++ b/eth_keys/datatypes.py
@@ -236,8 +236,6 @@ class PublicKey(BaseKey, LazyBackend):
 
 
 class PrivateKey(BaseKey, LazyBackend):
-    public_key: PublicKey = None
-
     def __init__(
         self,
         private_key_bytes: bytes,
@@ -247,8 +245,9 @@ class PrivateKey(BaseKey, LazyBackend):
 
         self._raw_key = private_key_bytes
 
-        self.public_key = self.backend.private_key_to_public_key(self)
         super().__init__(backend=backend)
+
+        self.public_key: PublicKey = self.backend.private_key_to_public_key(self)
 
     def sign_msg(self, message: bytes) -> "Signature":
         message_hash = keccak(message)

--- a/newsfragments/106.bugfix.rst
+++ b/newsfragments/106.bugfix.rst
@@ -1,0 +1,1 @@
+Makes ``PrivateKey.public_key`` explicitly an instance member instead of looking like it's a class member.


### PR DESCRIPTION
(1) public_key should only be an instance member of PrivateKey, not a class member.
(2) Cannot call `self.backend.private_key_to_public_key(self)` until `self.backend` is actually set. And that gets done by the superclass constructor. So we need to call super's constructor first, before we can set self.public_key (bug is only noticed if an explicit, non-native backend class is passed in to the PrivateKey constructor)