### PR TITLE
bump coincurve pin to >=17, add v21 ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,59 +266,6 @@ jobs:
       - <<: *run-tox-step
       - <<: *save-cache-step
 
-  py38-backends-coincurve12:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-backends-coincurve12
-
-  py38-backends-coincurve13:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-backends-coincurve13
-
-  py38-backends-coincurve14:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-backends-coincurve14
-
-  py38-backends-coincurve15:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-backends-coincurve15
-  py39-backends-coincurve15:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-        environment:
-          TOXENV: py39-backends-coincurve15
-
-  py38-backends-coincurve16:
-    <<: *common
-    docker:
-      - image: cimg/python:3.8
-        environment:
-          TOXENV: py38-backends-coincurve16
-  py39-backends-coincurve16:
-    <<: *common
-    docker:
-      - image: cimg/python:3.9
-        environment:
-          TOXENV: py39-backends-coincurve16
-  py310-backends-coincurve16:
-    <<: *common
-    docker:
-      - image: cimg/python:3.10
-        environment:
-          TOXENV: py310-backends-coincurve16
-
   py38-backends-coincurve17:
     <<: *common
     docker:
@@ -431,6 +378,37 @@ jobs:
         environment:
           TOXENV: py313-backends-coincurve20
 
+  py39-backends-coincurve21:
+    <<: *common
+    docker:
+      - image: cimg/python:3.9
+        environment:
+          TOXENV: py39-backends-coincurve21
+  py310-backends-coincurve21:
+    <<: *common
+    docker:
+      - image: cimg/python:3.10
+        environment:
+          TOXENV: py310-backends-coincurve21
+  py311-backends-coincurve21:
+    <<: *common
+    docker:
+      - image: cimg/python:3.11
+        environment:
+          TOXENV: py311-backends-coincurve21
+  py312-backends-coincurve21:
+    <<: *common
+    docker:
+      - image: cimg/python:3.12
+        environment:
+          TOXENV: py312-backends-coincurve21
+  py313-backends-coincurve21:
+    <<: *common
+    docker:
+      - image: cimg/python:3.13
+        environment:
+          TOXENV: py313-backends-coincurve21
+
 define: &all_jobs
   - docs
   - py38-core
@@ -454,14 +432,6 @@ define: &all_jobs
   - py311-windows-wheel
   - py312-windows-wheel
   - py313-windows-wheel
-  - py38-backends-coincurve12
-  - py38-backends-coincurve13
-  - py38-backends-coincurve14
-  - py38-backends-coincurve15
-  - py39-backends-coincurve15
-  - py38-backends-coincurve16
-  - py39-backends-coincurve16
-  - py310-backends-coincurve16
   - py38-backends-coincurve17
   - py39-backends-coincurve17
   - py310-backends-coincurve17
@@ -480,6 +450,11 @@ define: &all_jobs
   - py311-backends-coincurve20
   - py312-backends-coincurve20
   - py313-backends-coincurve20
+  - py39-backends-coincurve21
+  - py310-backends-coincurve21
+  - py311-backends-coincurve21
+  - py312-backends-coincurve21
+  - py313-backends-coincurve21
 
 workflows:
   version: 2

--- a/newsfragments/108.breaking.rst
+++ b/newsfragments/108.breaking.rst
@@ -1,0 +1,1 @@
+Drops support for ``coincurve<=16``, adds support for ``coincurve==21``.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import (
 
 extras_require = {
     "coincurve": [
-        "coincurve>=12.0.0",
+        "coincurve>=17.0.0",
     ],
     "dev": [
         "build>=0.9.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
 envlist=
-    py38-backends-coincurve{12,13,14}
-    py{38,39}-backends-coincurve15
-    py{38,39,310}-backends-coincurve{16,17}
+    py{38,39,310}-backends-coincurve17
     py{38,39,310,311}-backends-coincurve18
     py{38,39,310,311,312}-backends-coincurve19
     py{38,39,310,311,312,313}-backends-coincurve20
+    py{39,310,311,312,313}-backends-coincurve21
     py{38,39,310,311,312,313}-core
     py{38,39,310,311,312,313}-lint
     py{38,39,310,311,312,313}-wheel
@@ -37,15 +36,11 @@ basepython=
     py312: python3.12
     py313: python3.13
 deps= .[test]
-    coincurve12: coincurve>=12.0.0,<13.0.0
-    coincurve13: coincurve>=13.0.0,<14.0.0
-    coincurve14: coincurve>=14.0.0,<15.0.0
-    coincurve15: coincurve>=15.0.0,<16.0.0
-    coincurve16: coincurve>=16.0.0,<17.0.0
     coincurve17: coincurve>=17.0.0,<18.0.0
     coincurve18: coincurve>=18.0.0,<19.0.0
     coincurve19: coincurve>=19.0.1,<20.0.0
     coincurve20: coincurve>=20.0.0,<21.0.0
+    coincurve21: coincurve>=21.0.0,<22.0.0
 setenv=
     backends: REQUIRE_COINCURVE=True
 extras=


### PR DESCRIPTION
### What was wrong?

#101 introduces a bugfix to `eth-keys` that was fixed in coincurve v17. Coincuve has also released v21.

### How was it fixed?

To prep for merging #101, bump to `coincurve>=17.0.0` and drop related CI. Add CI for v21.

Coincurve v17 was released Jan 2022, long enough ago that this seems reasonable.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-keys/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/53b956db-03c7-4f03-ba75-37a9918b456f)
